### PR TITLE
Bump chart version to 0.2.7

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 
 # Image URL to use all building/pushing image targets
-IMG ?= oamdev/terraform-controller:0.2.6
+IMG ?= oamdev/terraform-controller:0.2.7
 
 # Produce CRDs that work back to Kubernetes 1.11 (no version conversion)
 CRD_OPTIONS ?= "crd:trivialVersions=true"

--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: terraform-controller
-version: 0.2.6
+version: 0.2.7
 description: A Kubernetes Terraform controller
 home: https://github.com/oam-dev/terraform-controller
 appVersion: "0.2.5"

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -1,10 +1,10 @@
 replicaCount: 1
 
-version: 0.2.6
+version: 0.2.7
 
 image:
   repository: oamdev/terraform-controller
-  tag: 0.2.6
+  tag: 0.2.7
   pullPolicy: Always
 
 terraformImage: oamdev/docker-terraform:1.0.7


### PR DESCRIPTION
In this release, no api is changed.