### PR TITLE
Use `Git` to replace `Remote`

### DIFF
--- a/api/types/terraform.go
+++ b/api/types/terraform.go
@@ -17,4 +17,6 @@ const (
 	ConfigurationHCL ConfigurationType = "HCL"
 	// ConfigurationRemote means HCL stores in a remote git repository
 	ConfigurationRemote ConfigurationType = "Remote"
+	// ConfigurationGit means HCL stores in a remote git repository
+	ConfigurationGit ConfigurationType = "Git"
 )

--- a/api/v1beta1/configuration_types.go
+++ b/api/v1beta1/configuration_types.go
@@ -32,6 +32,7 @@ type ConfigurationSpec struct {
 	HCL string `json:"hcl,omitempty"`
 
 	// Remote is a git repo which contains hcl files. Currently, only public git repos are supported.
+	// Deprecated in v0.3.1. Use BaseConfigurationSpec.Git instead.
 	Remote string `json:"remote,omitempty"`
 
 	// +kubebuilder:pruning:PreserveUnknownFields
@@ -66,6 +67,9 @@ type BaseConfigurationSpec struct {
 
 	// Region is cloud provider's region. It will override the region in the region field of ProviderReference
 	Region string `json:"region,omitempty"`
+
+	// Git is a git repo which contains Configuration(HCL) files. Currently, only public git repos are supported.
+	Git string `json:"git,omitempty"`
 }
 
 // ConfigurationStatus defines the observed state of Configuration

--- a/controllers/configuration/configuration.go
+++ b/controllers/configuration/configuration.go
@@ -36,8 +36,9 @@ func ValidConfigurationObject(configuration *v1beta1.Configuration) (types.Confi
 	json := configuration.Spec.JSON
 	hcl := configuration.Spec.HCL
 	remote := configuration.Spec.Remote
+	git := configuration.Spec.Git
 	switch {
-	case json == "" && hcl == "" && remote == "":
+	case json == "" && hcl == "" && remote == "" && git == "":
 		return "", errors.New("spec.JSON, spec.HCL or spec.Remote should be set")
 	case json != "" && hcl != "", json != "" && remote != "", hcl != "" && remote != "":
 		return "", errors.New("spec.JSON, spec.HCL and/or spec.Remote cloud not be set at the same time")
@@ -45,8 +46,8 @@ func ValidConfigurationObject(configuration *v1beta1.Configuration) (types.Confi
 		return types.ConfigurationJSON, nil
 	case hcl != "":
 		return types.ConfigurationHCL, nil
-	case remote != "":
-		return types.ConfigurationRemote, nil
+	case remote != "" || git != "":
+		return types.ConfigurationGit, nil
 	}
 	return "", nil
 }

--- a/controllers/configuration_controller.go
+++ b/controllers/configuration_controller.go
@@ -117,7 +117,7 @@ type TFConfigurationMeta struct {
 	Namespace             string
 	ConfigurationType     types.ConfigurationType
 	CompleteConfiguration string
-	RemoteGit             string
+	Git                   string
 	RemoteGitPath         string
 	ConfigurationChanged  bool
 	ConfigurationCMName   string
@@ -228,7 +228,7 @@ func initTFConfigurationMeta(req ctrl.Request, configuration v1beta1.Configurati
 		DestroyJobName:      req.Name + "-" + string(TerraformDestroy),
 	}
 
-	meta.RemoteGit = tfcfg.ReplaceTerraformSource(configuration.Spec.Remote, githubBlocked)
+	meta.Git = tfcfg.ReplaceTerraformSource(configuration.Spec.Remote, githubBlocked)
 	meta.DeleteResource = configuration.Spec.DeleteResource
 	if configuration.Spec.Path == "" {
 		meta.RemoteGitPath = "."
@@ -605,7 +605,7 @@ func (meta *TFConfigurationMeta) assembleTerraformJob(executionType TerraformExe
 
 	hclPath := filepath.Join(BackendVolumeMountPath, meta.RemoteGitPath)
 
-	if meta.RemoteGit != "" {
+	if meta.Git != "" {
 		initContainers = append(initContainers,
 			v1.Container{
 				Name:            "git-configuration",
@@ -614,7 +614,7 @@ func (meta *TFConfigurationMeta) assembleTerraformJob(executionType TerraformExe
 				Command: []string{
 					"sh",
 					"-c",
-					fmt.Sprintf("git clone %s %s && cp -r %s/* %s", meta.RemoteGit, BackendVolumeMountPath,
+					fmt.Sprintf("git clone %s %s && cp -r %s/* %s", meta.Git, BackendVolumeMountPath,
 						hclPath, WorkingVolumeMountPath),
 				},
 				VolumeMounts: initContainerVolumeMounts,


### PR DESCRIPTION
spec.Remote doesn't clearly show where the Configuration(HCL) are stored.
And we will support OSS/ConfigMap in the future

Signed-off-by: Zheng Xi Zhou <zzxwill@gmail.com>