### PR TITLE
[FEATURE] - Run Jobs in central namespace

### DIFF
--- a/chart/templates/terraform_controller.yaml
+++ b/chart/templates/terraform_controller.yaml
@@ -21,8 +21,8 @@ spec:
           image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           args:
-            {{- if .Values.jobNamespace }}
-            - --jobNamespace={{ .Values.jobNamespace }}
+            {{- if .Values.controllerNamespace }}
+            - --controller-namespace={{ .Values.controllerNamespace }}
             {{- end }}
           env:
             - name: CONTROLLER_NAMESPACE

--- a/chart/templates/terraform_controller.yaml
+++ b/chart/templates/terraform_controller.yaml
@@ -20,6 +20,10 @@ spec:
         - name: terraform-controller
           image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          args:
+            {{- if .Values.jobNamespace }}
+            - --jobNamespace={{ .Values.jobNamespace }}
+            {{- end }}
           env:
             - name: CONTROLLER_NAMESPACE
               valueFrom:

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -8,6 +8,7 @@ image:
 gitImage: alpine/git:latest
 busyboxImage: busybox:latest
 terraformImage: oamdev/docker-terraform:1.1.2
+jobNamespace: ""
 
 # "{\"nat\": \"true\"}"
 jobNodeSelector: ""

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -8,7 +8,7 @@ image:
 gitImage: alpine/git:latest
 busyboxImage: busybox:latest
 terraformImage: oamdev/docker-terraform:1.1.2
-jobNamespace: ""
+controllerNamespace: ""
 
 # "{\"nat\": \"true\"}"
 jobNodeSelector: ""

--- a/controllers/configuration_controller.go
+++ b/controllers/configuration_controller.go
@@ -27,6 +27,7 @@ import (
 	"reflect"
 	"time"
 
+	"github.com/davecgh/go-spew/spew"
 	"github.com/go-logr/logr"
 	"github.com/oam-dev/terraform-controller/controllers/configuration/backend"
 	"github.com/pkg/errors"
@@ -656,6 +657,8 @@ func (meta *TFConfigurationMeta) assembleAndTriggerJob(ctx context.Context, k8sC
 
 	job := meta.assembleTerraformJob(executionType)
 
+	fmt.Println("NAME", spew.Sdump(job.Name))
+
 	return k8sClient.Create(ctx, job)
 }
 
@@ -803,6 +806,7 @@ func (meta *TFConfigurationMeta) assembleTerraformJob(executionType TerraformExe
 
 	name := meta.ApplyJobName
 	if executionType == TerraformDestroy {
+		fmt.Println("HERE")
 		name = meta.DestroyJobName
 	}
 

--- a/controllers/configuration_controller.go
+++ b/controllers/configuration_controller.go
@@ -355,7 +355,6 @@ func (r *ConfigurationReconciler) terraformDestroy(ctx context.Context, configur
 			if kerrors.IsNotFound(err) {
 				if err := r.Client.Get(ctx, client.ObjectKey{Name: configuration.Name, Namespace: configuration.Namespace}, &v1beta2.Configuration{}); err == nil {
 					if err = meta.assembleAndTriggerJob(ctx, k8sClient, TerraformDestroy); err != nil {
-						fmt.Println("1")
 						return err
 					}
 				}

--- a/controllers/configuration_controller.go
+++ b/controllers/configuration_controller.go
@@ -68,10 +68,14 @@ const (
 )
 
 const (
+	// TerraformStateNameInSecret is the key name to store Terraform state
+	TerraformStateNameInSecret = "tfstate"
 	// TFInputConfigMapName is the CM name for Terraform Input Configuration
 	TFInputConfigMapName = "tf-%s"
 	// TFVariableSecret is the Secret name for variables, including credentials from Provider
 	TFVariableSecret = "variable-%s"
+	// TFBackendSecret is the Secret name for Kubernetes backend
+	TFBackendSecret = "tfstate-%s-%s"
 )
 
 // TerraformExecutionType is the type for Terraform execution
@@ -95,10 +99,10 @@ const (
 // ConfigurationReconciler reconciles a Configuration object.
 type ConfigurationReconciler struct {
 	client.Client
-	Log          logr.Logger
-	JobNamespace string
-	ProviderName string
-	Scheme       *runtime.Scheme
+	Log                 logr.Logger
+	ControllerNamespace string
+	ProviderName        string
+	Scheme              *runtime.Scheme
 }
 
 // +kubebuilder:rbac:groups=terraform.core.oam.dev,resources=configurations,verbs=get;list;watch;create;update;patch;delete
@@ -113,10 +117,8 @@ func (r *ConfigurationReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 		return ctrl.Result{}, client.IgnoreNotFound(err)
 	}
 
-	fmt.Println("HELLO", configuration)
-
 	meta := initTFConfigurationMeta(req, configuration)
-	if r.JobNamespace != "" {
+	if r.ControllerNamespace != "" {
 		uid := string(configuration.GetUID())
 		// @step: since we are using a single namespace to run these, we must ensure the names
 		// are unique across the namespace
@@ -124,8 +126,8 @@ func (r *ConfigurationReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 		meta.BackendSecretName = fmt.Sprintf(TFBackendSecret, terraformWorkspace, uid)
 		meta.ConfigurationCMName = fmt.Sprintf(TFInputConfigMapName, uid)
 		meta.DestroyJobName = uid + "-" + string(TerraformDestroy)
-		meta.JobNamespace = r.JobNamespace
-		meta.TerraformBackendNamespace = r.JobNamespace
+		meta.ControllerNamespace = r.ControllerNamespace
+		meta.TerraformBackendNamespace = r.ControllerNamespace
 		meta.VariableSecretName = fmt.Sprintf(TFVariableSecret, uid)
 
 		configuration.Spec.Backend = &v1beta2.Backend{
@@ -151,7 +153,7 @@ func (r *ConfigurationReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 	}
 
 	var tfExecutionJob = &batchv1.Job{}
-	if err := r.Client.Get(ctx, client.ObjectKey{Name: meta.ApplyJobName, Namespace: meta.JobNamespace}, tfExecutionJob); err == nil {
+	if err := r.Client.Get(ctx, client.ObjectKey{Name: meta.ApplyJobName, Namespace: meta.ControllerNamespace}, tfExecutionJob); err == nil {
 		if !meta.EnvChanged && tfExecutionJob.Status.Succeeded == int32(1) {
 			if err := meta.updateApplyStatus(ctx, r.Client, types.Available, types.MessageCloudResourceDeployed); err != nil {
 				return ctrl.Result{}, err
@@ -163,7 +165,7 @@ func (r *ConfigurationReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 		// terraform destroy
 		klog.InfoS("performing Configuration Destroy", "Namespace", req.Namespace, "Name", req.Name, "JobName", meta.DestroyJobName)
 
-		_, err := terraform.GetTerraformStatus(ctx, meta.Namespace, meta.DestroyJobName, meta.JobNamespace, terraformContainerName, terraformInitContainerName)
+		_, err := terraform.GetTerraformStatus(ctx, meta.Namespace, meta.DestroyJobName, meta.ControllerNamespace, terraformContainerName, terraformInitContainerName)
 		if err != nil {
 			klog.ErrorS(err, "Terraform destroy failed")
 			if updateErr := meta.updateDestroyStatus(ctx, r.Client, types.ConfigurationDestroyFailed, err.Error()); updateErr != nil {
@@ -199,7 +201,7 @@ func (r *ConfigurationReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 		}
 		return ctrl.Result{RequeueAfter: 3 * time.Second}, errors.Wrap(err, "failed to create/update cloud resource")
 	}
-	state, err := terraform.GetTerraformStatus(ctx, meta.Namespace, meta.ApplyJobName, meta.JobNamespace, terraformContainerName, terraformInitContainerName)
+	state, err := terraform.GetTerraformStatus(ctx, meta.Namespace, meta.ApplyJobName, meta.ControllerNamespace, terraformContainerName, terraformInitContainerName)
 	if err != nil {
 		klog.ErrorS(err, "Terraform apply failed")
 		if updateErr := meta.updateApplyStatus(ctx, r.Client, state, err.Error()); updateErr != nil {
@@ -216,7 +218,7 @@ func (r *ConfigurationReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 type TFConfigurationMeta struct {
 	Name                    string
 	Namespace               string
-	JobNamespace            string
+	ControllerNamespace     string
 	ConfigurationType       types.ConfigurationType
 	CompleteConfiguration   string
 	RemoteGit               string
@@ -257,7 +259,7 @@ type TFConfigurationMeta struct {
 
 func initTFConfigurationMeta(req ctrl.Request, configuration v1beta2.Configuration) *TFConfigurationMeta {
 	var meta = &TFConfigurationMeta{
-		JobNamespace:        req.Namespace,
+		ControllerNamespace: req.Namespace,
 		Namespace:           req.Namespace,
 		Name:                req.Name,
 		ConfigurationCMName: fmt.Sprintf(TFInputConfigMapName, req.Name),
@@ -307,7 +309,7 @@ func (r *ConfigurationReconciler) terraformApply(ctx context.Context, namespace 
 		tfExecutionJob batchv1.Job
 	)
 
-	if err := k8sClient.Get(ctx, client.ObjectKey{Name: meta.ApplyJobName, Namespace: meta.JobNamespace}, &tfExecutionJob); err != nil {
+	if err := k8sClient.Get(ctx, client.ObjectKey{Name: meta.ApplyJobName, Namespace: meta.ControllerNamespace}, &tfExecutionJob); err != nil {
 		if kerrors.IsNotFound(err) {
 			return meta.assembleAndTriggerJob(ctx, k8sClient, TerraformApply)
 		}
@@ -349,7 +351,7 @@ func (r *ConfigurationReconciler) terraformDestroy(ctx context.Context, configur
 	deleteConfigurationDirectly := deletable || !meta.DeleteResource
 
 	if !deleteConfigurationDirectly {
-		if err := k8sClient.Get(ctx, client.ObjectKey{Name: meta.DestroyJobName, Namespace: meta.JobNamespace}, &destroyJob); err != nil {
+		if err := k8sClient.Get(ctx, client.ObjectKey{Name: meta.DestroyJobName, Namespace: meta.ControllerNamespace}, &destroyJob); err != nil {
 			if kerrors.IsNotFound(err) {
 				if err := r.Client.Get(ctx, client.ObjectKey{Name: configuration.Name, Namespace: configuration.Namespace}, &v1beta2.Configuration{}); err == nil {
 					if err = meta.assembleAndTriggerJob(ctx, k8sClient, TerraformDestroy); err != nil {
@@ -379,7 +381,7 @@ func (r *ConfigurationReconciler) terraformDestroy(ctx context.Context, configur
 	}
 	// When the deletion Job process succeeded, clean up work is starting.
 	if !deleteConfigurationDirectly {
-		if err := k8sClient.Get(ctx, client.ObjectKey{Name: meta.DestroyJobName, Namespace: meta.JobNamespace}, &destroyJob); err != nil {
+		if err := k8sClient.Get(ctx, client.ObjectKey{Name: meta.DestroyJobName, Namespace: meta.ControllerNamespace}, &destroyJob); err != nil {
 			return err
 		}
 		if destroyJob.Status.Succeeded == int32(1) {
@@ -573,13 +575,13 @@ func (r *ConfigurationReconciler) preCheck(ctx context.Context, configuration *v
 	}
 
 	var variableInSecret v1.Secret
-	err = k8sClient.Get(ctx, client.ObjectKey{Name: meta.VariableSecretName, Namespace: meta.JobNamespace}, &variableInSecret)
+	err = k8sClient.Get(ctx, client.ObjectKey{Name: meta.VariableSecretName, Namespace: meta.ControllerNamespace}, &variableInSecret)
 	switch {
 	case kerrors.IsNotFound(err):
 		var secret = v1.Secret{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      meta.VariableSecretName,
-				Namespace: meta.JobNamespace,
+				Namespace: meta.ControllerNamespace,
 			},
 			TypeMeta: metav1.TypeMeta{Kind: "Secret"},
 			Data:     meta.VariableSecretData,
@@ -603,7 +605,7 @@ func (r *ConfigurationReconciler) preCheck(ctx context.Context, configuration *v
 		return err
 	}
 
-	return createTerraformExecutorClusterRole(ctx, k8sClient, fmt.Sprintf("%s-%s", meta.JobNamespace, ClusterRoleName))
+	return createTerraformExecutorClusterRole(ctx, k8sClient, fmt.Sprintf("%s-%s", meta.ControllerNamespace, ClusterRoleName))
 }
 
 func (meta *TFConfigurationMeta) updateApplyStatus(ctx context.Context, k8sClient client.Client, state types.ConfigurationState, message string) error {
@@ -646,10 +648,10 @@ func (meta *TFConfigurationMeta) updateDestroyStatus(ctx context.Context, k8sCli
 
 func (meta *TFConfigurationMeta) assembleAndTriggerJob(ctx context.Context, k8sClient client.Client, executionType TerraformExecutionType) error {
 	// apply rbac
-	if err := createTerraformExecutorServiceAccount(ctx, k8sClient, meta.JobNamespace, ServiceAccountName); err != nil {
+	if err := createTerraformExecutorServiceAccount(ctx, k8sClient, meta.ControllerNamespace, ServiceAccountName); err != nil {
 		return err
 	}
-	if err := createTerraformExecutorClusterRoleBinding(ctx, k8sClient, meta.JobNamespace, fmt.Sprintf("%s-%s", meta.JobNamespace, ClusterRoleName), ServiceAccountName); err != nil {
+	if err := createTerraformExecutorClusterRoleBinding(ctx, k8sClient, meta.ControllerNamespace, fmt.Sprintf("%s-%s", meta.ControllerNamespace, ClusterRoleName), ServiceAccountName); err != nil {
 		return err
 	}
 
@@ -671,7 +673,7 @@ func (meta *TFConfigurationMeta) updateTerraformJobIfNeeded(ctx context.Context,
 			}
 		}
 		var s v1.Secret
-		if err := k8sClient.Get(ctx, client.ObjectKey{Name: meta.VariableSecretName, Namespace: meta.JobNamespace}, &s); err == nil {
+		if err := k8sClient.Get(ctx, client.ObjectKey{Name: meta.VariableSecretName, Namespace: meta.ControllerNamespace}, &s); err == nil {
 			if deleteErr := k8sClient.Delete(ctx, &s); deleteErr != nil {
 				return deleteErr
 			}
@@ -812,7 +814,7 @@ func (meta *TFConfigurationMeta) assembleTerraformJob(executionType TerraformExe
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
-			Namespace: meta.JobNamespace,
+			Namespace: meta.ControllerNamespace,
 		},
 		Spec: batchv1.JobSpec{
 			Parallelism:  &parallelism,
@@ -1043,7 +1045,7 @@ func getTerraformJSONVariable(tfVariables *runtime.RawExtension) (map[string]int
 
 func (meta *TFConfigurationMeta) deleteConfigMap(ctx context.Context, k8sClient client.Client) error {
 	var cm v1.ConfigMap
-	if err := k8sClient.Get(ctx, client.ObjectKey{Name: meta.ConfigurationCMName, Namespace: meta.JobNamespace}, &cm); err == nil {
+	if err := k8sClient.Get(ctx, client.ObjectKey{Name: meta.ConfigurationCMName, Namespace: meta.ControllerNamespace}, &cm); err == nil {
 		if err := k8sClient.Delete(ctx, &cm); err != nil {
 			return err
 		}
@@ -1068,13 +1070,13 @@ func deleteConnectionSecret(ctx context.Context, k8sClient client.Client, name, 
 
 func (meta *TFConfigurationMeta) createOrUpdateConfigMap(ctx context.Context, k8sClient client.Client, data map[string]string) error {
 	var gotCM v1.ConfigMap
-	if err := k8sClient.Get(ctx, client.ObjectKey{Name: meta.ConfigurationCMName, Namespace: meta.JobNamespace}, &gotCM); err != nil {
+	if err := k8sClient.Get(ctx, client.ObjectKey{Name: meta.ConfigurationCMName, Namespace: meta.ControllerNamespace}, &gotCM); err != nil {
 		if kerrors.IsNotFound(err) {
 			cm := v1.ConfigMap{
 				TypeMeta: metav1.TypeMeta{APIVersion: "v1", Kind: "ConfigMap"},
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      meta.ConfigurationCMName,
-					Namespace: meta.JobNamespace,
+					Namespace: meta.ControllerNamespace,
 				},
 				Data: data,
 			}
@@ -1113,7 +1115,7 @@ func (meta *TFConfigurationMeta) storeTFConfiguration(ctx context.Context, k8sCl
 // CheckWhetherConfigurationChanges will check whether configuration is changed
 func (meta *TFConfigurationMeta) CheckWhetherConfigurationChanges(ctx context.Context, k8sClient client.Client, configurationType types.ConfigurationType) error {
 	var cm v1.ConfigMap
-	if err := k8sClient.Get(ctx, client.ObjectKey{Name: meta.ConfigurationCMName, Namespace: meta.JobNamespace}, &cm); err != nil {
+	if err := k8sClient.Get(ctx, client.ObjectKey{Name: meta.ConfigurationCMName, Namespace: meta.ControllerNamespace}, &cm); err != nil {
 		return err
 	}
 

--- a/controllers/configuration_controller.go
+++ b/controllers/configuration_controller.go
@@ -113,6 +113,8 @@ func (r *ConfigurationReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 		return ctrl.Result{}, client.IgnoreNotFound(err)
 	}
 
+	fmt.Println("HELLO", configuration)
+
 	meta := initTFConfigurationMeta(req, configuration)
 	if r.JobNamespace != "" {
 		uid := string(configuration.GetUID())

--- a/controllers/configuration_controller_test.go
+++ b/controllers/configuration_controller_test.go
@@ -553,7 +553,7 @@ func TestConfigurationReconcile(t *testing.T) {
 			},
 		},
 		{
-			name: "Builds should be run in job namespace",
+			name: "Builds should be run in the controller namespace when defined",
 			args: args{
 				req: req,
 				r:   r6,
@@ -1288,7 +1288,7 @@ func TestTerraformDestroy(t *testing.T) {
 				errMsg: "jobs.batch \"\" not found",
 			},
 		},
-		/*{
+		{
 			name: "referenced provider is not available",
 			args: args{
 				r:             r2,
@@ -1296,14 +1296,14 @@ func TestTerraformDestroy(t *testing.T) {
 				meta: &TFConfigurationMeta{
 					ConfigurationCMName: "tf-abc",
 					Namespace:           "default",
-					JobNamespace:        "default",
+					ControllerNamespace: "default",
 					DeleteResource:      true,
 				},
 			},
 			want: want{
 				errMsg: "jobs.batch \"\" not found",
 			},
-		},*/
+		},
 		{
 			name: "could not directly remove resources, and destroy job completes",
 			args: args{

--- a/controllers/configuration_controller_test.go
+++ b/controllers/configuration_controller_test.go
@@ -76,7 +76,7 @@ func TestInitTFConfigurationMeta(t *testing.T) {
 			},
 			want: &TFConfigurationMeta{
 				Namespace:           "default",
-				JobNamespace:        "default",
+				ControllerNamespace: "default",
 				Name:                "abc",
 				ConfigurationCMName: "tf-abc",
 				VariableSecretName:  "variable-abc",
@@ -95,7 +95,7 @@ func TestInitTFConfigurationMeta(t *testing.T) {
 			configuration: completeConfiguration,
 			want: &TFConfigurationMeta{
 				Namespace:           "default",
-				JobNamespace:        "default",
+				ControllerNamespace: "default",
 				Name:                "abc",
 				ConfigurationCMName: "tf-abc",
 				VariableSecretName:  "variable-abc",
@@ -493,7 +493,7 @@ func TestConfigurationReconcile(t *testing.T) {
 		},
 	}
 	namespace := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "builds"}}
-	r6 := &ConfigurationReconciler{JobNamespace: "builds"}
+	r6 := &ConfigurationReconciler{ControllerNamespace: "builds"}
 	r6.Client = fake.NewClientBuilder().
 		WithScheme(s).
 		WithObjects(namespace, secret, provider, configuration6).
@@ -514,7 +514,7 @@ func TestConfigurationReconcile(t *testing.T) {
 		want  want
 		check func(t *testing.T, cc client.Client)
 	}{
-		/*{
+		{
 			name: "Configuration is not found",
 			args: args{
 				req: req,
@@ -551,7 +551,7 @@ func TestConfigurationReconcile(t *testing.T) {
 				req: req,
 				r:   r5,
 			},
-		},*/
+		},
 		{
 			name: "Builds should be run in job namespace",
 			args: args{
@@ -560,7 +560,7 @@ func TestConfigurationReconcile(t *testing.T) {
 			},
 			check: func(t *testing.T, cc client.Client) {
 				job := &batchv1.Job{}
-				err := cc.Get(context.TODO(), k8stypes.NamespacedName{Name: "12345-apply", Namespace: "builds"}, job)
+				err := cc.Get(context.TODO(), k8stypes.NamespacedName{Name: "a-12345-apply", Namespace: "builds"}, job)
 				if err != nil {
 					t.Error("Failed to retrieve jobs from builds namespace")
 				}
@@ -1218,10 +1218,10 @@ func TestTerraformDestroy(t *testing.T) {
 	k8sClient4 := fake.NewClientBuilder().WithScheme(s).WithObjects(provider1, job4, secret4, variableSecret4, configuration4).Build()
 	r4.Client = k8sClient4
 	meta4 := &TFConfigurationMeta{
-		DestroyJobName: "a",
-		Namespace:      "default",
-		JobNamespace:   "default",
-		DeleteResource: true,
+		DestroyJobName:      "a",
+		Namespace:           "default",
+		ControllerNamespace: "default",
+		DeleteResource:      true,
 		ProviderReference: &crossplane.Reference{
 			Name:      "b",
 			Namespace: "default",
@@ -1281,7 +1281,7 @@ func TestTerraformDestroy(t *testing.T) {
 				meta: &TFConfigurationMeta{
 					ConfigurationCMName: "tf-abc",
 					Namespace:           "default",
-					JobNamespace:        "default",
+					ControllerNamespace: "default",
 				},
 			},
 			want: want{
@@ -1991,7 +1991,7 @@ func TestCheckWhetherConfigurationChanges(t *testing.T) {
 				meta: &TFConfigurationMeta{
 					ConfigurationCMName: "a",
 					Namespace:           "b",
-					JobNamespace:        "b",
+					ControllerNamespace: "b",
 				},
 				configurationType: "xxx",
 			},
@@ -2004,7 +2004,7 @@ func TestCheckWhetherConfigurationChanges(t *testing.T) {
 				meta: &TFConfigurationMeta{
 					ConfigurationCMName: "aaa",
 					Namespace:           "b",
-					JobNamespace:        "b",
+					ControllerNamespace: "b",
 				},
 				configurationType: "xxx",
 			},

--- a/controllers/configuration_controller_test.go
+++ b/controllers/configuration_controller_test.go
@@ -76,6 +76,7 @@ func TestInitTFConfigurationMeta(t *testing.T) {
 			},
 			want: &TFConfigurationMeta{
 				Namespace:           "default",
+				JobNamespace:        "default",
 				Name:                "abc",
 				ConfigurationCMName: "tf-abc",
 				VariableSecretName:  "variable-abc",
@@ -94,6 +95,7 @@ func TestInitTFConfigurationMeta(t *testing.T) {
 			configuration: completeConfiguration,
 			want: &TFConfigurationMeta{
 				Namespace:           "default",
+				JobNamespace:        "default",
 				Name:                "abc",
 				ConfigurationCMName: "tf-abc",
 				VariableSecretName:  "variable-abc",

--- a/controllers/configuration_controller_test.go
+++ b/controllers/configuration_controller_test.go
@@ -1236,6 +1236,20 @@ func TestTerraformDestroy(t *testing.T) {
 			want: want{},
 		},
 		{
+			name: "provider is not ready",
+			args: args{
+				r:             r1,
+				configuration: &v1beta2.Configuration{},
+				meta: &TFConfigurationMeta{
+					ConfigurationCMName: "tf-abc",
+					Namespace:           "default",
+				},
+			},
+			want: want{
+				errMsg: "jobs.batch \"\" not found",
+			},
+		},
+		{
 			name: "referenced provider is not available",
 			args: args{
 				r:             r2,

--- a/controllers/configuration_controller_test.go
+++ b/controllers/configuration_controller_test.go
@@ -1183,6 +1183,7 @@ func TestTerraformDestroy(t *testing.T) {
 	meta4 := &TFConfigurationMeta{
 		DestroyJobName: "a",
 		Namespace:      "default",
+		JobNamespace:   "default",
 		DeleteResource: true,
 		ProviderReference: &crossplane.Reference{
 			Name:      "b",
@@ -1243,13 +1244,14 @@ func TestTerraformDestroy(t *testing.T) {
 				meta: &TFConfigurationMeta{
 					ConfigurationCMName: "tf-abc",
 					Namespace:           "default",
+					JobNamespace:        "default",
 				},
 			},
 			want: want{
 				errMsg: "jobs.batch \"\" not found",
 			},
 		},
-		{
+		/*{
 			name: "referenced provider is not available",
 			args: args{
 				r:             r2,
@@ -1257,13 +1259,14 @@ func TestTerraformDestroy(t *testing.T) {
 				meta: &TFConfigurationMeta{
 					ConfigurationCMName: "tf-abc",
 					Namespace:           "default",
+					JobNamespace:        "default",
 					DeleteResource:      true,
 				},
 			},
 			want: want{
 				errMsg: "jobs.batch \"\" not found",
 			},
-		},
+		},*/
 		{
 			name: "could not directly remove resources, and destroy job completes",
 			args: args{
@@ -1284,7 +1287,7 @@ func TestTerraformDestroy(t *testing.T) {
 	}
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
-			err := tc.args.r.terraformDestroy(ctx, tc.args.namespace, *tc.args.configuration, tc.args.meta)
+			err := tc.args.r.terraformDestroy(ctx, *tc.args.configuration, tc.args.meta)
 			if err != nil || tc.want.errMsg != "" {
 				if !strings.Contains(err.Error(), tc.want.errMsg) {
 					t.Errorf("terraformDestroy() error = %v, wantErr %v", err, tc.want.errMsg)
@@ -1951,6 +1954,7 @@ func TestCheckWhetherConfigurationChanges(t *testing.T) {
 				meta: &TFConfigurationMeta{
 					ConfigurationCMName: "a",
 					Namespace:           "b",
+					JobNamespace:        "b",
 				},
 				configurationType: "xxx",
 			},
@@ -1963,6 +1967,7 @@ func TestCheckWhetherConfigurationChanges(t *testing.T) {
 				meta: &TFConfigurationMeta{
 					ConfigurationCMName: "aaa",
 					Namespace:           "b",
+					JobNamespace:        "b",
 				},
 				configurationType: "xxx",
 			},

--- a/controllers/configuration_controller_test.go
+++ b/controllers/configuration_controller_test.go
@@ -1169,6 +1169,14 @@ func TestTerraformDestroy(t *testing.T) {
 			Namespace: "default",
 			Name:      "b",
 		},
+		Spec: v1beta2.ConfigurationSpec{
+			BaseConfigurationSpec: v1beta2.BaseConfigurationSpec{
+				ProviderReference: &runtimetypes.Reference{
+					Name:      "not_there",
+					Namespace: "not_there",
+				},
+			},
+		},
 	}
 	k8sClient2 := fake.NewClientBuilder().WithScheme(s).WithObjects(provider1, configuration).Build()
 	r2.Client = k8sClient2
@@ -1295,9 +1303,9 @@ func TestTerraformDestroy(t *testing.T) {
 				configuration: configuration,
 				meta: &TFConfigurationMeta{
 					ConfigurationCMName: "tf-abc",
-					Namespace:           "default",
 					ControllerNamespace: "default",
 					DeleteResource:      true,
+					Namespace:           "default",
 				},
 			},
 			want: want{

--- a/controllers/provider/credentials_test.go
+++ b/controllers/provider/credentials_test.go
@@ -374,6 +374,21 @@ func TestGetProviderCredentials(t *testing.T) {
 			},
 			errMsg: "unsupported provider",
 		},
+		{
+			name: "credentials injected as source, should return an error",
+			args: args{
+				k8sClient: k8sClient1,
+				provider: v1beta1.Provider{
+					Spec: v1beta1.ProviderSpec{
+						Credentials: v1beta1.ProviderCredentials{
+							Source: "InjectedIdentity",
+						},
+						Provider: "aws",
+					},
+				},
+			},
+			errMsg: ErrCredentialNotRetrieved,
+		},
 	}
 
 	for _, tt := range tests {

--- a/controllers/provider/credentials_test.go
+++ b/controllers/provider/credentials_test.go
@@ -374,28 +374,13 @@ func TestGetProviderCredentials(t *testing.T) {
 			},
 			errMsg: "unsupported provider",
 		},
-		{
-			name: "credentials injected as source, should return an error",
-			args: args{
-				k8sClient: k8sClient1,
-				provider: v1beta1.Provider{
-					Spec: v1beta1.ProviderSpec{
-						Credentials: v1beta1.ProviderCredentials{
-							Source: "InjectedIdentity",
-						},
-						Provider: "aws",
-					},
-				},
-			},
-			errMsg: ErrCredentialNotRetrieved,
-		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got, err := GetProviderCredentials(ctx, tt.args.k8sClient, &tt.args.provider, tt.args.region)
 			if tt.errMsg != "" && err != nil && !strings.Contains(err.Error(), tt.errMsg) {
-				t.Errorf("GetProviderCredentials() error = %v, wantErr %v", err, err.Error())
+				t.Errorf("GetProviderCredentials() error = %q, wantErr %q", err, err.Error())
 				return
 			}
 			if !reflect.DeepEqual(got, tt.want) {

--- a/controllers/provider_controller.go
+++ b/controllers/provider_controller.go
@@ -28,7 +28,6 @@ import (
 	"k8s.io/klog/v2"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
 	"github.com/oam-dev/terraform-controller/api/types"
 	terraformv1beta1 "github.com/oam-dev/terraform-controller/api/v1beta1"
@@ -99,6 +98,5 @@ func (r *ProviderReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 func (r *ProviderReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&terraformv1beta1.Provider{}).
-		WithEventFilter(&predicate.GenerationChangedPredicate{}).
 		Complete(r)
 }

--- a/controllers/provider_controller.go
+++ b/controllers/provider_controller.go
@@ -65,12 +65,11 @@ func (r *ProviderReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 
 	err := func() error {
 		switch provider.Spec.Credentials.Source {
-		case crossplanetypes.CredentialsSourceSecret:
-			if _, err := providercred.GetProviderCredentials(ctx, r.Client, &provider, provider.Spec.Region); err != nil {
-				return err
-			}
 		case crossplanetypes.CredentialsSourceInjectedIdentity:
 			break
+		case crossplanetypes.CredentialsSourceSecret:
+			_, err := providercred.GetProviderCredentials(ctx, r.Client, &provider, provider.Spec.Region)
+			return err
 		default:
 			return errors.Errorf("unsupported credentials source: %s", provider.Spec.Credentials.Source)
 		}
@@ -93,7 +92,7 @@ func (r *ProviderReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 		return ctrl.Result{}, errors.Wrap(updateErr, errSettingStatus)
 	}
 
-	return ctrl.Result{}, nil
+	return ctrl.Result{}, err
 }
 
 // SetupWithManager setups with a manager

--- a/controllers/provider_controller_test.go
+++ b/controllers/provider_controller_test.go
@@ -130,21 +130,21 @@ func TestReconcile(t *testing.T) {
 			want: want{},
 		},
 		{
-			name: "Provider is found, but the secret is not available",
+			name: "Provider is found but the secret is not available",
 			args: args{
 				req: req,
 				r:   r3,
 			},
 			want: want{
-				errMsg: errGetCredentials,
+				errMsg: `failed to get the Secret from Provider: secrets "abc" not found`,
 			},
 		},
 	}
 
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
-			if _, err := tc.args.r.Reconcile(ctx, tc.args.req); (tc.want.errMsg != "") &&
-				!strings.Contains(err.Error(), tc.want.errMsg) {
+			_, err := tc.args.r.Reconcile(ctx, tc.args.req)
+			if tc.want.errMsg != "" && !strings.Contains(err.Error(), tc.want.errMsg) {
 				t.Errorf("Reconcile() error = %v, wantErr %v", err, tc.want.errMsg)
 			}
 		})

--- a/controllers/provider_controller_test.go
+++ b/controllers/provider_controller_test.go
@@ -94,6 +94,32 @@ func TestReconcile(t *testing.T) {
 
 	r3.Client = fake.NewClientBuilder().WithScheme(s).WithObjects(provider3).Build()
 
+	r4 := &ProviderReconciler{}
+	provider4 := &v1beta1.Provider{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "aws",
+			Namespace: "default",
+		},
+		Spec: v1beta1.ProviderSpec{
+			Credentials: v1beta1.ProviderCredentials{Source: "InjectedIdentity"},
+			Provider:    "aws",
+		},
+	}
+	r4.Client = fake.NewClientBuilder().WithScheme(s).WithObjects(provider4).Build()
+
+	r5 := &ProviderReconciler{}
+	provider5 := &v1beta1.Provider{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "aws",
+			Namespace: "default",
+		},
+		Spec: v1beta1.ProviderSpec{
+			Credentials: v1beta1.ProviderCredentials{Source: "Invalid"},
+			Provider:    "aws",
+		},
+	}
+	r5.Client = fake.NewClientBuilder().WithScheme(s).WithObjects(provider5).Build()
+
 	type args struct {
 		req reconcile.Request
 		r   *ProviderReconciler
@@ -137,6 +163,24 @@ func TestReconcile(t *testing.T) {
 			},
 			want: want{
 				errMsg: `failed to get the Secret from Provider: secrets "abc" not found`,
+			},
+		},
+		{
+			name: "Provider is using source injected identity",
+			args: args{
+				req: req,
+				r:   r4,
+			},
+			want: want{},
+		},
+		{
+			name: "Provider source is invalid",
+			args: args{
+				req: req,
+				r:   r5,
+			},
+			want: want{
+				errMsg: `unsupported credentials source: Invalid`,
 			},
 		},
 	}

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -27,6 +27,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
 	"sigs.k8s.io/controller-runtime/pkg/envtest/printer"
+
 	// +kubebuilder:scaffold:imports
 
 	terraformv1beta1 "github.com/oam-dev/terraform-controller/api/v1beta1"

--- a/controllers/terraform/logging.go
+++ b/controllers/terraform/logging.go
@@ -20,8 +20,10 @@ func getPods(ctx context.Context, client kubernetes.Interface, namespace, jobNam
 	pods, err := client.CoreV1().Pods(namespace).List(ctx, metav1.ListOptions{LabelSelector: label})
 	if err != nil {
 		klog.InfoS("pods are not found", "Label", label, "Error", err)
+
 		return nil, err
 	}
+
 	return pods, nil
 }
 

--- a/controllers/terraform/status.go
+++ b/controllers/terraform/status.go
@@ -12,7 +12,7 @@ import (
 )
 
 // GetTerraformStatus will get Terraform execution status
-func GetTerraformStatus(ctx context.Context, namespace, jobName, containerName, initContainerName string) (types.ConfigurationState, error) {
+func GetTerraformStatus(ctx context.Context, namespace, jobName, jobNamespace, containerName, initContainerName string) (types.ConfigurationState, error) {
 	klog.InfoS("checking Terraform init and execution status", "Namespace", namespace, "Job", jobName)
 	clientSet, err := client.Init()
 	if err != nil {
@@ -21,8 +21,7 @@ func GetTerraformStatus(ctx context.Context, namespace, jobName, containerName, 
 	}
 
 	// check the stage of the pod
-
-	stage, logs, err := getPodLog(ctx, clientSet, namespace, jobName, containerName, initContainerName)
+	stage, logs, err := getPodLog(ctx, clientSet, jobNamespace, jobName, containerName, initContainerName)
 	if err != nil {
 		klog.ErrorS(err, "failed to get pod logs")
 		return types.ConfigurationProvisioningAndChecking, err
@@ -52,5 +51,6 @@ func analyzeTerraformLog(logs string, stage types.Stage) (bool, types.Configurat
 			}
 		}
 	}
+
 	return true, types.ConfigurationProvisioningAndChecking, ""
 }

--- a/controllers/terraform/status_test.go
+++ b/controllers/terraform/status_test.go
@@ -49,7 +49,7 @@ func TestGetTerraformStatus(t *testing.T) {
 	}
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
-			state, err := GetTerraformStatus(ctx, tc.args.namespace, tc.args.name, tc.args.containerName, "")
+			state, err := GetTerraformStatus(ctx, tc.args.namespace, tc.args.name, tc.args.namespace, tc.args.containerName, "")
 			if tc.want.errMsg != "" {
 				assert.EqualError(t, err, tc.want.errMsg)
 			} else {
@@ -92,7 +92,7 @@ func TestGetTerraformStatus2(t *testing.T) {
 	}
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
-			state, err := GetTerraformStatus(ctx, tc.args.namespace, tc.args.name, tc.args.containerName, "")
+			state, err := GetTerraformStatus(ctx, tc.args.namespace, tc.args.name, tc.args.namespace, tc.args.containerName, "")
 			if tc.want.errMsg != "" {
 				assert.Contains(t, err.Error(), tc.want.errMsg)
 			} else {

--- a/main.go
+++ b/main.go
@@ -50,13 +50,13 @@ func main() {
 	var enableLeaderElection bool
 	var syncPeriod time.Duration
 	var namespace string
-	var jobNamespace string
+	var controllerNamespace string
 
 	flag.BoolVar(&enableLeaderElection, "enable-leader-election", false, "Enable leader election for controller manager, this will ensure there is only one active controller manager.")
 	flag.DurationVar(&syncPeriod, "informer-re-sync-interval", 10*time.Second, "controller shared informer lister full re-sync period")
 	flag.StringVar(&metricsAddr, "metrics-addr", ":38080", "The address the metric endpoint binds to.")
 	flag.StringVar(&namespace, "namespace", "", "Namespace to watch for resources, defaults to all namespaces")
-	flag.StringVar(&jobNamespace, "job-namespace", "", "Namespace to watch run the terraform jobs, defaults to resource namespace")
+	flag.StringVar(&controllerNamespace, "controller-namespace", "vela-system", "Namespace to run the terraform jobs")
 
 	// embed klog
 	klog.InitFlags(nil)
@@ -79,10 +79,10 @@ func main() {
 	}
 
 	if err = (&controllers.ConfigurationReconciler{
-		Client:       mgr.GetClient(),
-		JobNamespace: jobNamespace,
-		Log:          ctrl.Log.WithName("controllers").WithName("Configuration"),
-		Scheme:       mgr.GetScheme(),
+		Client:              mgr.GetClient(),
+		ControllerNamespace: controllerNamespace,
+		Log:                 ctrl.Log.WithName("controllers").WithName("Configuration"),
+		Scheme:              mgr.GetScheme(),
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "Configuration")
 		os.Exit(1)

--- a/main.go
+++ b/main.go
@@ -56,7 +56,7 @@ func main() {
 	flag.DurationVar(&syncPeriod, "informer-re-sync-interval", 10*time.Second, "controller shared informer lister full re-sync period")
 	flag.StringVar(&metricsAddr, "metrics-addr", ":38080", "The address the metric endpoint binds to.")
 	flag.StringVar(&namespace, "namespace", "", "Namespace to watch for resources, defaults to all namespaces")
-	flag.StringVar(&controllerNamespace, "controller-namespace", "vela-system", "Namespace to run the terraform jobs")
+	flag.StringVar(&controllerNamespace, "controller-namespace", "terraform", "Namespace to run the terraform jobs")
 
 	// embed klog
 	klog.InitFlags(nil)

--- a/main.go
+++ b/main.go
@@ -40,7 +40,6 @@ var (
 
 func init() {
 	_ = clientgoscheme.AddToScheme(scheme)
-
 	_ = terraformv1beta1.AddToScheme(scheme)
 	_ = v1beta2.AddToScheme(scheme)
 	// +kubebuilder:scaffold:scheme
@@ -50,12 +49,15 @@ func main() {
 	var metricsAddr string
 	var enableLeaderElection bool
 	var syncPeriod time.Duration
+	var namespace string
+	var jobNamespace string
+
+	flag.BoolVar(&enableLeaderElection, "enable-leader-election", false, "Enable leader election for controller manager, this will ensure there is only one active controller manager.")
+	flag.DurationVar(&syncPeriod, "informer-re-sync-interval", 10*time.Second, "controller shared informer lister full re-sync period")
 	flag.StringVar(&metricsAddr, "metrics-addr", ":38080", "The address the metric endpoint binds to.")
-	flag.BoolVar(&enableLeaderElection, "enable-leader-election", false,
-		"Enable leader election for controller manager. "+
-			"Enabling this will ensure there is only one active controller manager.")
-	flag.DurationVar(&syncPeriod, "informer-re-sync-interval", 10*time.Second,
-		"controller shared informer lister full re-sync period")
+	flag.StringVar(&namespace, "namespace", "", "Namespace to watch for resources, defaults to all namespaces")
+	flag.StringVar(&jobNamespace, "job-namespace", "", "Namespace to watch run the terraform jobs, defaults to resource namespace")
+
 	// embed klog
 	klog.InitFlags(nil)
 	flag.Parse()
@@ -63,11 +65,12 @@ func main() {
 	ctrl.SetLogger(klogr.New())
 
 	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
-		Scheme:             scheme,
-		MetricsBindAddress: metricsAddr,
-		Port:               9443,
 		LeaderElection:     enableLeaderElection,
 		LeaderElectionID:   "ce329a9c.core.oam.dev",
+		MetricsBindAddress: metricsAddr,
+		Namespace:          namespace,
+		Port:               9443,
+		Scheme:             scheme,
 		SyncPeriod:         &syncPeriod,
 	})
 	if err != nil {
@@ -76,9 +79,10 @@ func main() {
 	}
 
 	if err = (&controllers.ConfigurationReconciler{
-		Client: mgr.GetClient(),
-		Log:    ctrl.Log.WithName("controllers").WithName("Configuration"),
-		Scheme: mgr.GetScheme(),
+		Client:       mgr.GetClient(),
+		JobNamespace: jobNamespace,
+		Log:          ctrl.Log.WithName("controllers").WithName("Configuration"),
+		Scheme:       mgr.GetScheme(),
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "Configuration")
 		os.Exit(1)

--- a/main.go
+++ b/main.go
@@ -56,7 +56,7 @@ func main() {
 	flag.DurationVar(&syncPeriod, "informer-re-sync-interval", 10*time.Second, "controller shared informer lister full re-sync period")
 	flag.StringVar(&metricsAddr, "metrics-addr", ":38080", "The address the metric endpoint binds to.")
 	flag.StringVar(&namespace, "namespace", "", "Namespace to watch for resources, defaults to all namespaces")
-	flag.StringVar(&controllerNamespace, "controller-namespace", "terraform", "Namespace to run the terraform jobs")
+	flag.StringVar(&controllerNamespace, "controller-namespace", "", "Namespace to run the terraform jobs")
 
 	// embed klog
 	klog.InitFlags(nil)


### PR DESCRIPTION
Currently all jobs are run in the namespace the `configuration` CRD is created in, which given how the provider secret implementation works (copying the secret into the desiganated namespace) exposes central credentials. This PR adds a conntroller flag (`--job-namespace`) which runs all jobs in a specific namespace and ensuring any secrets are never exposed beyond that boundary. 

- Also add the ability to run the jobs under a serviceaccount, extending the Provider CRD. When run via the `--job-namespace` the platform administrator can provision a service account with Pod identity (EKS IRSA) and remove the need for static secrets.