### PR TITLE
Feat: expose region in status

### DIFF
--- a/api/v1beta2/configuration_types.go
+++ b/api/v1beta2/configuration_types.go
@@ -93,6 +93,9 @@ type ConfigurationApplyStatus struct {
 	State   state.ConfigurationState `json:"state,omitempty"`
 	Message string                   `json:"message,omitempty"`
 	Outputs map[string]Property      `json:"outputs,omitempty"`
+	// Region is the region for the cloud resources created by this Configuration. If spec.region is not empty, it's the
+	// value of it. Otherwise, it's the value of spec.providerReference.region.
+	Region string `json:"region,omitempty"`
 }
 
 // ConfigurationDestroyStatus is the status for Configuration destroy

--- a/chart/crds/terraform.core.oam.dev_configurations.yaml
+++ b/chart/crds/terraform.core.oam.dev_configurations.yaml
@@ -307,6 +307,11 @@ spec:
                           type: string
                       type: object
                     type: object
+                  region:
+                    description: Region is the region for the cloud resources created
+                      by this Configuration. If spec.region is not empty, it's the
+                      value of it. Otherwise, it's the value of spec.providerReference.region.
+                    type: string
                   state:
                     description: A ConfigurationState represents the status of a resource
                     type: string

--- a/controllers/configuration_controller.go
+++ b/controllers/configuration_controller.go
@@ -208,6 +208,7 @@ type TFConfigurationMeta struct {
 	VariableSecretName    string
 	VariableSecretData    map[string][]byte
 	DeleteResource        bool
+	Region                string
 	Credentials           map[string]string
 
 	Backend backend.Backend
@@ -582,6 +583,7 @@ func (meta *TFConfigurationMeta) updateApplyStatus(ctx context.Context, k8sClien
 		configuration.Status.Apply = v1beta2.ConfigurationApplyStatus{
 			State:   state,
 			Message: message,
+			Region:  meta.Region,
 		}
 		configuration.Status.ObservedGeneration = configuration.Generation
 		if state == types.Available {
@@ -1110,5 +1112,6 @@ func (meta *TFConfigurationMeta) getCredentials(ctx context.Context, k8sClient c
 		return errors.New(provider.ErrCredentialNotRetrieved)
 	}
 	meta.Credentials = credentials
+	meta.Region = region
 	return nil
 }


### PR DESCRIPTION
Region is the region for the cloud resources created by this Configuration.
If spec.region is not empty, it's the value of it. Otherwise, it's the value
of spec.providerReference.region.

Signed-off-by: Zheng Xi Zhou <zhengxi.zzx@alibaba-inc.com>
