### PR TITLE
Fix some bugs of `backup_restore` tool

### DIFF
--- a/hack/tool/backup_restore/cmd/backup.go
+++ b/hack/tool/backup_restore/cmd/backup.go
@@ -39,11 +39,15 @@ var (
 func newBackupCmd(kubeFlags *genericclioptions.ConfigFlags) *cobra.Command {
 	backupCmd := &cobra.Command{
 		Use: "backup",
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return app.BuildK8SClient(kubeFlags)
+		PreRun: func(cmd *cobra.Command, args []string) {
+			if err := app.BuildK8SClient(kubeFlags); err != nil {
+				log.Fatal(err)
+			}
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
-			return backup(context.Background())
+		Run: func(cmd *cobra.Command, args []string) {
+			if err := backup(context.Background()); err != nil {
+				log.Fatal(err)
+			}
 		},
 	}
 	backupCmd.Flags().StringArrayVar(&configurationNameList, "configuration", []string{}, "the name of the configurations which need to be backed up")

--- a/hack/tool/backup_restore/cmd/restore.go
+++ b/hack/tool/backup_restore/cmd/restore.go
@@ -115,16 +115,15 @@ func restore(ctx context.Context) error {
 func presetTFBackendNS() {
 	backendNS := os.Getenv(app.TFBackendNS)
 	if backendNS != "" {
-		goto end
+		log.Printf("use the `TERRAFORM_BACKEND_NAMESPACE` environment variable: %s", backendNS)
 	}
 
-	// if user don't set the "TERRAFORM_BACKEND_NAMESPACE" environment variable,
+	// if user doesn't set the "TERRAFORM_BACKEND_NAMESPACE" environment variable,
 	// we try to fetch the environment variable from the terraform-controller deployment
 	// and set it in the local environment to make sure the consistency
 	backendNS = app.GetTFBackendNSFromDeployment()
 	if backendNS != "" {
 		_ = os.Setenv(app.TFBackendNS, backendNS)
 	}
-end:
 	log.Printf("use the `TERRAFORM_BACKEND_NAMESPACE` environment variable: %s", backendNS)
 }

--- a/hack/tool/backup_restore/cmd/restore.go
+++ b/hack/tool/backup_restore/cmd/restore.go
@@ -38,14 +38,10 @@ var (
 func newRestoreCmd(kubeFlags *genericclioptions.ConfigFlags) *cobra.Command {
 	restoreCmd := &cobra.Command{
 		Use: "restore",
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			err := app.BuildK8SClient(kubeFlags)
-			if err != nil {
-				return err
-			}
+		PreRun: func(cmd *cobra.Command, args []string) {
 			pwd, err := os.Getwd()
 			if err != nil {
-				return err
+				log.Fatal(err)
 			}
 			if stateJSONPath == "" {
 				log.Fatal("`--state` should not be empty")
@@ -65,10 +61,15 @@ func newRestoreCmd(kubeFlags *genericclioptions.ConfigFlags) *cobra.Command {
 					log.Print("WARN: `--component` is empty. Will take the first component of the Application as the cloud resource which should be restored")
 				}
 			}
-			return nil
+			if err := app.BuildK8SClient(kubeFlags); err != nil {
+				log.Fatal(err)
+			}
+			presetTFBackendNS()
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
-			return restore(context.Background())
+		Run: func(cmd *cobra.Command, args []string) {
+			if err := restore(context.Background()); err != nil {
+				log.Fatal(err)
+			}
 		},
 	}
 	restoreCmd.Flags().StringVar(&stateJSONPath, "state", "state.json", "the path of the backed up Terraform state file")
@@ -108,4 +109,22 @@ func restore(ctx context.Context) error {
 	}
 
 	return app.WaitConfiguration(ctx, resourceOwner.GetConfigurationNamespacedName())
+}
+
+// presetTFBackendNS try to set the "TERRAFORM_BACKEND_NAMESPACE" environment variable
+func presetTFBackendNS() {
+	backendNS := os.Getenv(app.TFBackendNS)
+	if backendNS != "" {
+		goto end
+	}
+
+	// if user don't set the "TERRAFORM_BACKEND_NAMESPACE" environment variable,
+	// we try to fetch the environment variable from the terraform-controller deployment
+	// and set it in the local environment to make sure the consistency
+	backendNS = app.GetTFBackendNSFromDeployment()
+	if backendNS != "" {
+		_ = os.Setenv(app.TFBackendNS, backendNS)
+	}
+end:
+	log.Printf("use the `TERRAFORM_BACKEND_NAMESPACE` environment variable: %s", backendNS)
 }

--- a/hack/tool/backup_restore/cmd/restore.go
+++ b/hack/tool/backup_restore/cmd/restore.go
@@ -116,6 +116,7 @@ func presetTFBackendNS() {
 	backendNS := os.Getenv(app.TFBackendNS)
 	if backendNS != "" {
 		log.Printf("use the `TERRAFORM_BACKEND_NAMESPACE` environment variable: %s", backendNS)
+		return
 	}
 
 	// if user doesn't set the "TERRAFORM_BACKEND_NAMESPACE" environment variable,

--- a/hack/tool/backup_restore/internal/app/configuration.go
+++ b/hack/tool/backup_restore/internal/app/configuration.go
@@ -113,6 +113,11 @@ func WaitConfiguration(ctx context.Context, namespacedName *crossplane.Reference
 		gotConf := &v1beta2.Configuration{}
 		for {
 			if err := K8SClient.Get(ctx, client.ObjectKey{Name: namespacedName.Name, Namespace: namespacedName.Namespace}, gotConf); err != nil {
+				if kerrors.IsNotFound(err) {
+					log.Printf("can not find the configuration({Name: %s, Namespace: %s}), waiting......", namespacedName.Name, namespacedName.Namespace)
+					time.Sleep(500 * time.Millisecond)
+					continue
+				}
 				errCh <- err
 				return
 			}

--- a/hack/tool/backup_restore/internal/app/env.go
+++ b/hack/tool/backup_restore/internal/app/env.go
@@ -17,9 +17,16 @@ limitations under the License.
 package app
 
 import (
+	"context"
+	"log"
 	"os"
 	"strings"
+
+	appsv1 "k8s.io/api/apps/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
+
+const TFBackendNS = "TERRAFORM_BACKEND_NAMESPACE"
 
 func GetAllENVs() map[string]string {
 	envs := make(map[string]string)
@@ -28,4 +35,19 @@ func GetAllENVs() map[string]string {
 		envs[kv[0]] = kv[1]
 	}
 	return envs
+}
+
+func GetTFBackendNSFromDeployment() string {
+	deployment := appsv1.Deployment{}
+	if err := K8SClient.Get(context.Background(), client.ObjectKey{Name: "terraform-controller", Namespace: "vela-system"}, &deployment); err != nil {
+		log.Printf("WARN: get terraform-controller deployment in the vela-system namesapce failed, %v", err)
+		return ""
+	}
+	envs := deployment.Spec.Template.Spec.Containers[0].Env
+	for _, env := range envs {
+		if env.Name == "TERRAFORM_BACKEND_NAMESPACE" {
+			return env.Value
+		}
+	}
+	return ""
 }


### PR DESCRIPTION
1. try to wait the Configuration object to be created when restore application
2. don't print the help information when run the `backup_restore` tool failed
3. try to read the value of the `TERRAFORM_BACKEND_NAMESPACE` env from the terraform-controller deployment if user doesn't set it in the local environment

Signed-off-by: loheagn <loheagn@icloud.com>