### PR TITLE
Fix: apply job recreation

### DIFF
--- a/controllers/configuration_controller.go
+++ b/controllers/configuration_controller.go
@@ -118,7 +118,7 @@ func (r *ConfigurationReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 		uid := string(configuration.GetUID())
 		// @step: since we are using a single namespace to run these, we must ensure the names
 		// are unique across the namespace
-		meta.KeepLegacySubResourceMetas(*configuration.Spec.Backend)
+		meta.KeepLegacySubResourceMetas()
 		meta.ApplyJobName = uid + "-" + string(TerraformApply)
 		meta.DestroyJobName = uid + "-" + string(TerraformDestroy)
 		meta.ConfigurationCMName = fmt.Sprintf(TFInputConfigMapName, uid)
@@ -218,7 +218,6 @@ type LegacySubResources struct {
 	DestroyJobName      string
 	ConfigurationCMName string
 	VariableSecretName  string
-	Backend             v1beta2.Backend
 }
 
 // TFConfigurationMeta is all the metadata of a Configuration
@@ -1223,13 +1222,12 @@ func (meta *TFConfigurationMeta) getCredentials(ctx context.Context, k8sClient c
 	return nil
 }
 
-func (meta *TFConfigurationMeta) KeepLegacySubResourceMetas(backend v1beta2.Backend) {
+func (meta *TFConfigurationMeta) KeepLegacySubResourceMetas() {
 	meta.LegacySubResources.Namespace = meta.Namespace
 	meta.LegacySubResources.ApplyJobName = meta.ApplyJobName
 	meta.LegacySubResources.DestroyJobName = meta.DestroyJobName
 	meta.LegacySubResources.ConfigurationCMName = meta.ConfigurationCMName
 	meta.LegacySubResources.VariableSecretName = meta.VariableSecretName
-	meta.LegacySubResources.Backend = backend
 }
 
 func (meta *TFConfigurationMeta) getApplyJob(ctx context.Context, k8sClient client.Client, job *batchv1.Job) error {

--- a/controllers/configuration_controller.go
+++ b/controllers/configuration_controller.go
@@ -118,7 +118,7 @@ func (r *ConfigurationReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 		uid := string(configuration.GetUID())
 		// @step: since we are using a single namespace to run these, we must ensure the names
 		// are unique across the namespace
-		meta.KeepLegacySubResourceMetas()
+		meta.KeepLegacySubResourceMetas(*configuration.Spec.Backend)
 		meta.ApplyJobName = uid + "-" + string(TerraformApply)
 		meta.DestroyJobName = uid + "-" + string(TerraformDestroy)
 		meta.ConfigurationCMName = fmt.Sprintf(TFInputConfigMapName, uid)
@@ -218,6 +218,7 @@ type LegacySubResources struct {
 	DestroyJobName      string
 	ConfigurationCMName string
 	VariableSecretName  string
+	Backend             v1beta2.Backend
 }
 
 // TFConfigurationMeta is all the metadata of a Configuration
@@ -1222,12 +1223,13 @@ func (meta *TFConfigurationMeta) getCredentials(ctx context.Context, k8sClient c
 	return nil
 }
 
-func (meta *TFConfigurationMeta) KeepLegacySubResourceMetas() {
+func (meta *TFConfigurationMeta) KeepLegacySubResourceMetas(backend v1beta2.Backend) {
 	meta.LegacySubResources.Namespace = meta.Namespace
 	meta.LegacySubResources.ApplyJobName = meta.ApplyJobName
 	meta.LegacySubResources.DestroyJobName = meta.DestroyJobName
 	meta.LegacySubResources.ConfigurationCMName = meta.ConfigurationCMName
 	meta.LegacySubResources.VariableSecretName = meta.VariableSecretName
+	meta.LegacySubResources.Backend = backend
 }
 
 func (meta *TFConfigurationMeta) getApplyJob(ctx context.Context, k8sClient client.Client, job *batchv1.Job) error {

--- a/controllers/terraform/status.go
+++ b/controllers/terraform/status.go
@@ -12,8 +12,8 @@ import (
 )
 
 // GetTerraformStatus will get Terraform execution status
-func GetTerraformStatus(ctx context.Context, namespace, jobName, jobNamespace, containerName, initContainerName string) (types.ConfigurationState, error) {
-	klog.InfoS("checking Terraform init and execution status", "Namespace", namespace, "Job", jobName)
+func GetTerraformStatus(ctx context.Context, jobNamespace, jobName, containerName, initContainerName string) (types.ConfigurationState, error) {
+	klog.InfoS("checking Terraform init and execution status", "Namespace", jobNamespace, "Job", jobName)
 	clientSet, err := client.Init()
 	if err != nil {
 		klog.ErrorS(err, "failed to init clientSet")

--- a/controllers/terraform/status_test.go
+++ b/controllers/terraform/status_test.go
@@ -49,7 +49,7 @@ func TestGetTerraformStatus(t *testing.T) {
 	}
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
-			state, err := GetTerraformStatus(ctx, tc.args.namespace, tc.args.name, tc.args.namespace, tc.args.containerName, "")
+			state, err := GetTerraformStatus(ctx, tc.args.name, tc.args.namespace, tc.args.containerName, "")
 			if tc.want.errMsg != "" {
 				assert.EqualError(t, err, tc.want.errMsg)
 			} else {

--- a/controllers/terraform/status_test.go
+++ b/controllers/terraform/status_test.go
@@ -92,7 +92,7 @@ func TestGetTerraformStatus2(t *testing.T) {
 	}
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
-			state, err := GetTerraformStatus(ctx, tc.args.namespace, tc.args.name, tc.args.namespace, tc.args.containerName, "")
+			state, err := GetTerraformStatus(ctx, tc.args.name, tc.args.namespace, tc.args.containerName, "")
 			if tc.want.errMsg != "" {
 				assert.Contains(t, err.Error(), tc.want.errMsg)
 			} else {


### PR DESCRIPTION
1. For now, if we restart terraform-controller with `--controller-namespace`. It couldn't get legacy Apply Job which is proves the resources has been created.  
This PR fix it by getting both kind of apply job.

2. Trim some useless code.

Signed-off-by: Qiaozp <qiaozhongpei.qzp@alibaba-inc.com>