### PR TITLE
Fix: legacy backend state reading and GC 

### DIFF
--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -61,6 +61,9 @@ jobs:
           make configuration
         env:
           TERRAFORM_BACKEND_NAMESPACE: terraform
+      - name: dump controller logs
+        if: ${{ always() }}
+        run: kubectl logs deploy/terraform-controller -n terraform
 
       - name: Upload coverage report
         uses: codecov/codecov-action@v2

--- a/Makefile
+++ b/Makefile
@@ -267,7 +267,8 @@ custom: custom-credentials custom-provider
 
 
 configuration:
-	go test -coverprofile=e2e-coverage1.xml -v ./e2e/... -count=1
+	go test -coverprofile=e2e-coverage1.xml -v $(go list ./e2e/...|grep -v controllernamespace) -count=1
+	go test -v ./e2e/controllernamespace/...
 
 e2e-setup: install-chart alibaba
 

--- a/controllers/configuration/configuration.go
+++ b/controllers/configuration/configuration.go
@@ -6,7 +6,6 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/oam-dev/terraform-controller/controllers/configuration/backend"
 	"github.com/pkg/errors"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	apitypes "k8s.io/apimachinery/pkg/types"
@@ -48,25 +47,6 @@ func ValidConfigurationObject(configuration *v1beta2.Configuration) (types.Confi
 		return types.ConfigurationRemote, nil
 	}
 	return "", nil
-}
-
-// RenderConfiguration will compose the Terraform configuration with hcl/json and backend
-func RenderConfiguration(configuration *v1beta2.Configuration, k8sClient client.Client, configurationType types.ConfigurationType, credentials map[string]string) (string, backend.Backend, error) {
-	backendInterface, err := backend.ParseConfigurationBackend(configuration, k8sClient, credentials)
-	if err != nil {
-		return "", nil, errors.Wrap(err, "failed to prepare Terraform backend configuration")
-	}
-
-	switch configurationType {
-	case types.ConfigurationHCL:
-		completedConfiguration := configuration.Spec.HCL
-		completedConfiguration += "\n" + backendInterface.HCL()
-		return completedConfiguration, backendInterface, nil
-	case types.ConfigurationRemote:
-		return backendInterface.HCL(), backendInterface, nil
-	default:
-		return "", nil, errors.New("Unsupported Configuration Type")
-	}
 }
 
 // SetRegion will set the region for Configuration

--- a/e2e/controllernamespace/controllernamespace_test.go
+++ b/e2e/controllernamespace/controllernamespace_test.go
@@ -1,0 +1,126 @@
+package controllernamespace
+
+import (
+	"context"
+	types2 "github.com/oam-dev/terraform-controller/api/types"
+	"strings"
+	"time"
+
+	crossplane "github.com/oam-dev/terraform-controller/api/types/crossplane-runtime"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/pkg/errors"
+	appv1 "k8s.io/api/apps/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	pkgClient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/config"
+
+	"github.com/oam-dev/terraform-controller/api/v1beta2"
+)
+
+var _ = Describe("Restart with controller-namespace", func() {
+	const (
+		defaultNamespace    = "default"
+		controllerNamespace = "terraform"
+		chartNamespace      = "terraform"
+	)
+	var (
+		controllerDeployMeta = types.NamespacedName{Name: "terraform-controller", Namespace: chartNamespace}
+	)
+	ctx := context.Background()
+
+	// create k8s rest config
+	restConf, err := config.GetConfig()
+	Expect(err).NotTo(HaveOccurred())
+	k8sClient, err := pkgClient.New(restConf, pkgClient.Options{})
+	s := k8sClient.Scheme()
+	_ = v1beta2.AddToScheme(s)
+	Expect(err).NotTo(HaveOccurred())
+
+	configuration := &v1beta2.Configuration{
+		ObjectMeta: v1.ObjectMeta{
+			Name:      "e2e-for-ctrl-ns",
+			Namespace: defaultNamespace,
+		},
+		Spec: v1beta2.ConfigurationSpec{
+			HCL: `
+resource "random_id" "server" {
+  byte_length = 8
+}
+    
+output "random_id" {
+  value = random_id.server.hex
+}`,
+			InlineCredentials: true,
+			WriteConnectionSecretToReference: &crossplane.SecretReference{
+				Name:      "some-conn",
+				Namespace: defaultNamespace,
+			},
+		},
+	}
+	AfterEach(func() {
+		_ = k8sClient.Delete(ctx, configuration)
+	})
+	It("Restart with controller namespace", func() {
+		By("apply configuration without --controller-namespace", func() {
+			err = k8sClient.Create(ctx, configuration)
+			Expect(err).NotTo(HaveOccurred())
+			var cfg = &v1beta2.Configuration{}
+			Eventually(func() error {
+				err = k8sClient.Get(ctx, types.NamespacedName{Name: configuration.Name, Namespace: configuration.Namespace}, cfg)
+				if err != nil {
+					return err
+				}
+				if cfg.Status.Apply.State != types2.Available {
+					return errors.Errorf("configuration is not available, status now: %s", cfg.Status.Apply.State)
+				}
+				return nil
+			}, time.Second*60, time.Second*5).Should(Succeed())
+		})
+		By("restart controller with --controller-namespace", func() {
+			ctrlDeploy := appv1.Deployment{}
+			err = k8sClient.Get(ctx, controllerDeployMeta, &ctrlDeploy)
+			Expect(err).NotTo(HaveOccurred())
+			ctrlDeploy.Spec.Template.Spec.Containers[0].Args = append(ctrlDeploy.Spec.Template.Spec.Containers[0].Args, "--controller-namespace="+controllerNamespace)
+			err := k8sClient.Update(ctx, &ctrlDeploy)
+			Expect(err).NotTo(HaveOccurred())
+
+			Eventually(func() error {
+				err := k8sClient.Get(ctx, controllerDeployMeta, &ctrlDeploy)
+				if err != nil {
+					return err
+				}
+				if ctrlDeploy.Status.UnavailableReplicas == 1 {
+					return errors.New("controller is not updated")
+				}
+				return nil
+			}, time.Second*60, time.Second*5).Should(Succeed())
+
+		})
+		By("configuration should be still available", func() {
+			// wait about half minute to check configuration's state isn't changed
+			for i := 0; i < 30; i++ {
+				err := k8sClient.Get(ctx, types.NamespacedName{
+					Name: configuration.Name, Namespace: configuration.Namespace,
+				}, configuration)
+				Expect(err).NotTo(HaveOccurred())
+				time.Sleep(time.Second)
+			}
+		})
+		By("restore controller", func() {
+			ctrlDeploy := appv1.Deployment{}
+			err = k8sClient.Get(ctx, controllerDeployMeta, &ctrlDeploy)
+			Expect(err).NotTo(HaveOccurred())
+			cmds := make([]string, 0)
+			for _, cmd := range ctrlDeploy.Spec.Template.Spec.Containers[0].Args {
+				if !strings.HasPrefix(cmd, "--controller-namespace") {
+					cmds = append(cmds, cmd)
+				}
+			}
+			ctrlDeploy.Spec.Template.Spec.Containers[0].Args = cmds
+			err := k8sClient.Update(ctx, &ctrlDeploy)
+			Expect(err).NotTo(HaveOccurred())
+		})
+	})
+})

--- a/e2e/controllernamespace/e2e_suite_test.go
+++ b/e2e/controllernamespace/e2e_suite_test.go
@@ -1,0 +1,14 @@
+package controllernamespace_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestE2e(t *testing.T) {
+	RegisterFailHandler(Fail)
+	defer GinkgoRecover()
+	RunSpecs(t, "E2e Suite")
+}

--- a/e2e/normal/configuration_test.go
+++ b/e2e/normal/configuration_test.go
@@ -1,6 +1,7 @@
-package e2e
+package normal
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"os/exec"
@@ -9,7 +10,6 @@ import (
 	"testing"
 	"time"
 
-	"golang.org/x/net/context"
 	"gotest.tools/assert"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -29,6 +29,8 @@ var (
 		"examples/alibaba/oss/configuration_hcl_bucket.yaml",
 	}
 	testConfigurationsForceDelete = "examples/random/configuration_force_delete.yaml"
+
+	chartNamespace = "terraform"
 )
 
 type ConfigurationAttr struct {

--- a/e2e/normal/regression.go
+++ b/e2e/normal/regression.go
@@ -1,4 +1,4 @@
-package e2e
+package normal
 
 import (
 	"fmt"

--- a/gitee/gitee_configuration_test.go
+++ b/gitee/gitee_configuration_test.go
@@ -1,9 +1,8 @@
 package gitee
 
 import (
+	"github.com/oam-dev/terraform-controller/e2e/normal"
 	"testing"
-
-	"github.com/oam-dev/terraform-controller/e2e"
 )
 
 var (
@@ -16,5 +15,5 @@ var (
 func TestGiteeConfigurationRegression(t *testing.T) {
 	var retryTimes = 240
 
-	e2e.Regression(t, giteeConfigurationsRegression, retryTimes)
+	normal.Regression(t, giteeConfigurationsRegression, retryTimes)
 }

--- a/go.mod
+++ b/go.mod
@@ -12,10 +12,9 @@ require (
 	github.com/hashicorp/hcl/v2 v2.12.0
 	github.com/jinzhu/copier v0.3.5
 	github.com/onsi/ginkgo v1.16.4
-	github.com/onsi/gomega v1.14.0
+	github.com/onsi/gomega v1.19.0
 	github.com/pkg/errors v0.9.1
 	github.com/stretchr/testify v1.7.0
-	golang.org/x/net v0.0.0-20220127200216-cd36cc0744dd
 	gopkg.in/yaml.v2 v2.4.0
 	gotest.tools v2.2.0+incompatible
 	k8s.io/api v0.21.3
@@ -60,8 +59,9 @@ require (
 	github.com/prometheus/procfs v0.6.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/zclconf/go-cty v1.10.0 // indirect
+	golang.org/x/net v0.0.0-20220225172249-27dd8689420f // indirect
 	golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d // indirect
-	golang.org/x/sys v0.0.0-20211216021012-1d35b9e2eb4e // indirect
+	golang.org/x/sys v0.0.0-20220319134239-a9b59b0215f8 // indirect
 	golang.org/x/term v0.0.0-20210927222741-03fcf44c2211 // indirect
 	golang.org/x/text v0.3.7 // indirect
 	golang.org/x/time v0.0.0-20210723032227-1f47c861a9ac // indirect

--- a/go.sum
+++ b/go.sum
@@ -199,6 +199,7 @@ github.com/google/pprof v0.0.0-20190515194954-54271f7e092f/go.mod h1:zfwlbNMJ+OI
 github.com/google/pprof v0.0.0-20191218002539-d4f498aebedc/go.mod h1:ZgVRPoUq/hfqzAqh7sHMqb3I9Rq5C59dIz2SbBwJ4eM=
 github.com/google/pprof v0.0.0-20200212024743-f11f1df84d12/go.mod h1:ZgVRPoUq/hfqzAqh7sHMqb3I9Rq5C59dIz2SbBwJ4eM=
 github.com/google/pprof v0.0.0-20200229191704-1ebb73c60ed3/go.mod h1:ZgVRPoUq/hfqzAqh7sHMqb3I9Rq5C59dIz2SbBwJ4eM=
+github.com/google/pprof v0.0.0-20210407192527-94a9f03dee38/go.mod h1:kpwsk12EmLew5upagYY7GY0pfYCcupk39gWOCRROcvE=
 github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm40UhjYkI=
 github.com/google/uuid v1.0.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/google/uuid v1.1.1/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
@@ -246,6 +247,7 @@ github.com/hashicorp/memberlist v0.1.3/go.mod h1:ajVTdAv/9Im8oMAAj5G31PhhMCZJV2p
 github.com/hashicorp/serf v0.8.2/go.mod h1:6hOLApaqBFA1NXqRQAsxw9QxuDEvNxSQRwA/JwenrHc=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
+github.com/ianlancetaylor/demangle v0.0.0-20200824232613-28f6c0f3b639/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/imdario/mergo v0.3.5/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJh5FfA=
 github.com/imdario/mergo v0.3.12 h1:b6R2BslTbIEToALKP7LxUvijTsNI9TAe80pLWN2g/HU=
 github.com/imdario/mergo v0.3.12/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH0dnCYA=
@@ -337,12 +339,16 @@ github.com/onsi/ginkgo v1.11.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+
 github.com/onsi/ginkgo v1.12.1/go.mod h1:zj2OWP4+oCPe1qIXoGWkgMRwljMUYCdkwsT2108oapk=
 github.com/onsi/ginkgo v1.16.4 h1:29JGrr5oVBm5ulCWet69zQkzWipVXIol6ygQUe/EzNc=
 github.com/onsi/ginkgo v1.16.4/go.mod h1:dX+/inL/fNMqNlz0e9LfyB9TswhZpCVdJM/Z6Vvnwo0=
+github.com/onsi/ginkgo/v2 v2.1.3 h1:e/3Cwtogj0HA+25nMP1jCMDIf8RtRYbGwGGuBIFztkc=
+github.com/onsi/ginkgo/v2 v2.1.3/go.mod h1:vw5CSIxN1JObi/U8gcbwft7ZxR2dgaR70JSE3/PpL4c=
 github.com/onsi/gomega v0.0.0-20170829124025-dcabb60a477c/go.mod h1:C1qb7wdrVGGVU+Z6iS04AVkA3Q65CEZX59MT0QO5uiA=
 github.com/onsi/gomega v1.7.0/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1CpauHY=
 github.com/onsi/gomega v1.7.1/go.mod h1:XdKZgCCFLUoM/7CFJVPcG8C1xQ1AJ0vpAezJrB7JYyY=
 github.com/onsi/gomega v1.10.1/go.mod h1:iN09h71vgCQne3DLsj+A5owkum+a2tYe+TOCB1ybHNo=
-github.com/onsi/gomega v1.14.0 h1:ep6kpPVwmr/nTbklSx2nrLNSIO62DoYAhnPNIMhK8gI=
 github.com/onsi/gomega v1.14.0/go.mod h1:cIuvLEne0aoVhAgh/O6ac0Op8WWw9H6eYCriF+tEHG0=
+github.com/onsi/gomega v1.17.0/go.mod h1:HnhC7FXeEQY45zxNK3PPoIUhzk/80Xly9PcubAlGdZY=
+github.com/onsi/gomega v1.19.0 h1:4ieX6qQjPP/BfC3mpsAtIGGlxTWPeA3Inl/7DtXw1tw=
+github.com/onsi/gomega v1.19.0/go.mod h1:LY+I3pBVzYsTBU1AnDwOSxaYi9WoWiqgwooUqq9yPro=
 github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
 github.com/peterbourgon/diskv v2.0.1+incompatible/go.mod h1:uqqh8zWWbv1HBMNONnaR/tNboyR3/BZd58JJSHlUSCU=
@@ -531,8 +537,9 @@ golang.org/x/net v0.0.0-20200625001655-4c5254603344/go.mod h1:/O7V0waA8r7cgGh81R
 golang.org/x/net v0.0.0-20201021035429-f5854403a974/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
 golang.org/x/net v0.0.0-20210224082022-3d97a244fca7/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
 golang.org/x/net v0.0.0-20210428140749-89ef3d95e781/go.mod h1:OJAsFXCWl8Ukc7SiCT/9KSuxbyM7479/AVlXFRxuMCk=
-golang.org/x/net v0.0.0-20220127200216-cd36cc0744dd h1:O7DYs+zxREGLKzKoMQrtrEacpb0ZVXA5rIwylE2Xchk=
 golang.org/x/net v0.0.0-20220127200216-cd36cc0744dd/go.mod h1:CfG3xpIq0wQ8r1q4Su4UZFWDARRcnwPjda9FqA0JpMk=
+golang.org/x/net v0.0.0-20220225172249-27dd8689420f h1:oA4XRj0qtSt8Yo1Zms0CUlsT3KG69V2UGQWPBxujDmc=
+golang.org/x/net v0.0.0-20220225172249-27dd8689420f/go.mod h1:CfG3xpIq0wQ8r1q4Su4UZFWDARRcnwPjda9FqA0JpMk=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20190226205417-e64efc72b421/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
 golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
@@ -594,8 +601,9 @@ golang.org/x/sys v0.0.0-20210426230700-d19ff857e887/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20210603081109-ebe580a85c40/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.0.0-20211216021012-1d35b9e2eb4e h1:fLOSk5Q00efkSvAm+4xcoXD+RRmLmmulPn5I3Y9F2EM=
 golang.org/x/sys v0.0.0-20211216021012-1d35b9e2eb4e/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20220319134239-a9b59b0215f8 h1:OH54vjqzRWmbJ62fjuhxy7AxFFgoHN0/DPc/UrL8cAs=
+golang.org/x/sys v0.0.0-20220319134239-a9b59b0215f8/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201117132131-f5c789dd3221/go.mod h1:Nr5EML6q2oocZ2LXRh80K7BxOlk5/8JxuGnuhpl+muw=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/term v0.0.0-20210220032956-6a3ed077a48d/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=


### PR DESCRIPTION
For now if restart controller with `--controller-namespace`. The configuration state will become `GeneratingTerraformOutputs` and stuck. This is because controller can't got the legacy backend. 

Fix that `Configuration.Spec.Backend` will be overwritten if set `--controller-namespace`. Instead, now controller 
 only overwrite `Configuration.Spec.Backend`  when no backend specified.

**How is this tested**

Add both unittest and e2e test

Signed-off-by: Qiaozp <qiaozhongpei.qzp@alibaba-inc.com>