### PR TITLE
feat: add libc6-compat to fix dynamic linking issue, add ca-certificates

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,6 +27,6 @@ COPY --from=builder /workspace/manager .
 # COPY terraform binary
 COPY bin/terraform /usr/bin/terraform
 #RUN chmod +x /usr/bin/terraform
-RUN apk add git
+RUN apk add git libc6-compat ca-certificates
 
 ENTRYPOINT ["/manager"]


### PR DESCRIPTION
 add libc6-compat library to fix dynamic linking issue in alpine for provider built with ubuntu. add ca-certificates to add well known cers to the truststore.