### PR TITLE
Feat: allow delete the provisioning resources

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -82,7 +82,7 @@ ifeq (, $(shell which controller-gen))
 	CONTROLLER_GEN_TMP_DIR=$$(mktemp -d) ;\
 	cd $$CONTROLLER_GEN_TMP_DIR ;\
 	go mod init tmp ;\
-	go install sigs.k8s.io/controller-tools/cmd/controller-gen@v0.6.0 ;\
+	go install sigs.k8s.io/controller-tools/cmd/controller-gen@v0.6.2 ;\
 	rm -rf $$CONTROLLER_GEN_TMP_DIR ;\
 	}
 CONTROLLER_GEN=$(GOBIN)/controller-gen
@@ -267,7 +267,7 @@ custom: custom-credentials custom-provider
 
 
 configuration:
-	go test -coverprofile=e2e-coverage1.xml -v $(go list ./e2e/...|grep -v controllernamespace) -count=1
+	go test -coverprofile=e2e-coverage1.xml -v $(shell go list ./e2e/...|grep -v controllernamespace) -count=1
 	go test -v ./e2e/controllernamespace/...
 
 e2e-setup: install-chart alibaba

--- a/api/v1beta2/configuration_types.go
+++ b/api/v1beta2/configuration_types.go
@@ -165,7 +165,8 @@ type S3BackendConf struct {
 // Configuration is the Schema for the configurations API
 // +kubebuilder:storageversion
 // +kubebuilder:subresource:status
-// +kubebuilder:printcolumn:name="STATE",type="string",JSONPath=".status.apply.state"
+// +kubebuilder:printcolumn:name="APPLY",type="string",JSONPath=".status.apply.state"
+// +kubebuilder:printcolumn:name="DESTROY",type="string",JSONPath=".status.destroy.state"
 // +kubebuilder:printcolumn:name="AGE",type="date",JSONPath=".metadata.creationTimestamp"
 type Configuration struct {
 	metav1.TypeMeta   `json:",inline"`

--- a/chart/crds/terraform.core.oam.dev_configurations.yaml
+++ b/chart/crds/terraform.core.oam.dev_configurations.yaml
@@ -4,7 +4,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.6.0
+    controller-gen.kubebuilder.io/version: v0.6.2
   creationTimestamp: null
   name: configurations.terraform.core.oam.dev
 spec:
@@ -218,7 +218,10 @@ spec:
       status: {}
   - additionalPrinterColumns:
     - jsonPath: .status.apply.state
-      name: STATE
+      name: APPLY
+      type: string
+    - jsonPath: .status.destroy.state
+      name: DESTROY
       type: string
     - jsonPath: .metadata.creationTimestamp
       name: AGE

--- a/chart/crds/terraform.core.oam.dev_providers.yaml
+++ b/chart/crds/terraform.core.oam.dev_providers.yaml
@@ -4,7 +4,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.6.0
+    controller-gen.kubebuilder.io/version: v0.6.2
   creationTimestamp: null
   name: providers.terraform.core.oam.dev
 spec:

--- a/chart/templates/terraform_controller.yaml
+++ b/chart/templates/terraform_controller.yaml
@@ -24,7 +24,7 @@ spec:
             {{- if .Values.controllerNamespace }}
             - --controller-namespace={{ .Values.controllerNamespace }}
             {{- end }}
-            - --feature-gates=AllowDeleteHalfway={{ .Values.featureGates.allowDeleteHalfway }}
+            - --feature-gates=AllowDeleteProvisioningResource={{ .Values.featureGates.AllowDeleteProvisioningResource }}
           env:
             - name: CONTROLLER_NAMESPACE
               valueFrom:

--- a/chart/templates/terraform_controller.yaml
+++ b/chart/templates/terraform_controller.yaml
@@ -24,6 +24,7 @@ spec:
             {{- if .Values.controllerNamespace }}
             - --controller-namespace={{ .Values.controllerNamespace }}
             {{- end }}
+            - --feature-gates=AllowDeleteHalfway={{ .Values.featureGates.allowDeleteHalfway }}
           env:
             - name: CONTROLLER_NAMESPACE
               valueFrom:

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -25,3 +25,9 @@ backend:
   namespace: vela-system
 
 githubBlocked: "'false'"
+
+featureGates:
+  # Enable the feature of allowing to delete a configuration whose cloud resources is not fully provisioned, or error happens
+  # This guarantees that the partial cloud resources will be deleted when the configuration is deleted
+  # Default value is true
+  allowDeleteHalfway: true

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -16,10 +16,10 @@ jobNodeSelector: ""
 resources:
   limits:
     cpu: "500m"
-    memory: "1Gi"
+    memory: "500Mi"
   requests:
-    cpu: "500m"
-    memory: "1Gi"
+    cpu: "250m"
+    memory: "250Mi"
 
 backend:
   namespace: vela-system

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -15,11 +15,11 @@ jobNodeSelector: ""
 
 resources:
   limits:
-    cpu: "1000m"
-    memory: "2Gi"
+    cpu: "500m"
+    memory: "1Gi"
   requests:
-    cpu: "1000m"
-    memory: "2Gi"
+    cpu: "500m"
+    memory: "1Gi"
 
 backend:
   namespace: vela-system
@@ -30,4 +30,4 @@ featureGates:
   # Enable the feature of allowing to delete a configuration whose cloud resources is not fully provisioned, or error happens
   # This guarantees that the partial cloud resources will be deleted when the configuration is deleted
   # Default value is true
-  allowDeleteHalfway: true
+  AllowDeleteProvisioningResource: true

--- a/controllers/configuration/configuration.go
+++ b/controllers/configuration/configuration.go
@@ -3,14 +3,13 @@ package configuration
 import (
 	"context"
 	"fmt"
-	"github.com/oam-dev/terraform-controller/controllers/features"
-	"k8s.io/apiserver/pkg/util/feature"
 	"strconv"
 	"strings"
 
 	"github.com/pkg/errors"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	apitypes "k8s.io/apimachinery/pkg/types"
+	"k8s.io/apiserver/pkg/util/feature"
 	"k8s.io/klog/v2"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -18,6 +17,7 @@ import (
 	crossplane "github.com/oam-dev/terraform-controller/api/types/crossplane-runtime"
 	"github.com/oam-dev/terraform-controller/api/v1beta1"
 	"github.com/oam-dev/terraform-controller/api/v1beta2"
+	"github.com/oam-dev/terraform-controller/controllers/features"
 	"github.com/oam-dev/terraform-controller/controllers/provider"
 )
 

--- a/controllers/configuration/configuration.go
+++ b/controllers/configuration/configuration.go
@@ -3,6 +3,8 @@ package configuration
 import (
 	"context"
 	"fmt"
+	"github.com/oam-dev/terraform-controller/controllers/features"
+	"k8s.io/apiserver/pkg/util/feature"
 	"strconv"
 	"strings"
 
@@ -82,9 +84,13 @@ func Get(ctx context.Context, k8sClient client.Client, namespacedName apitypes.N
 
 // IsDeletable will check whether the Configuration can be deleted immediately
 // If deletable, it means
+// - feature gate AllowDeleteHalfway is enabled
 // - no external cloud resources are provisioned
 // - it's in force-delete state
 func IsDeletable(ctx context.Context, k8sClient client.Client, configuration *v1beta2.Configuration) (bool, error) {
+	if feature.DefaultFeatureGate.Enabled(features.AllowDeleteHalfway) {
+		return true, nil
+	}
 	if configuration.Spec.ForceDelete != nil && *configuration.Spec.ForceDelete {
 		return true, nil
 	}

--- a/controllers/configuration/configuration.go
+++ b/controllers/configuration/configuration.go
@@ -84,11 +84,11 @@ func Get(ctx context.Context, k8sClient client.Client, namespacedName apitypes.N
 
 // IsDeletable will check whether the Configuration can be deleted immediately
 // If deletable, it means
-// - feature gate AllowDeleteHalfway is enabled
+// - feature gate AllowDeleteProvisioningResource is enabled
 // - no external cloud resources are provisioned
 // - it's in force-delete state
 func IsDeletable(ctx context.Context, k8sClient client.Client, configuration *v1beta2.Configuration) (bool, error) {
-	if feature.DefaultFeatureGate.Enabled(features.AllowDeleteHalfway) {
+	if feature.DefaultFeatureGate.Enabled(features.AllowDeleteProvisioningResource) {
 		return true, nil
 	}
 	if configuration.Spec.ForceDelete != nil && *configuration.Spec.ForceDelete {

--- a/controllers/configuration_controller.go
+++ b/controllers/configuration_controller.go
@@ -21,8 +21,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"github.com/oam-dev/terraform-controller/controllers/features"
-	"k8s.io/apiserver/pkg/util/feature"
 	"math"
 	"os"
 	"path/filepath"
@@ -30,7 +28,6 @@ import (
 	"time"
 
 	"github.com/go-logr/logr"
-	"github.com/oam-dev/terraform-controller/controllers/configuration/backend"
 	"github.com/pkg/errors"
 	batchv1 "k8s.io/api/batch/v1"
 	v1 "k8s.io/api/core/v1"
@@ -38,6 +35,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apiserver/pkg/util/feature"
 	"k8s.io/klog/v2"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -48,6 +46,8 @@ import (
 	"github.com/oam-dev/terraform-controller/api/v1beta1"
 	"github.com/oam-dev/terraform-controller/api/v1beta2"
 	tfcfg "github.com/oam-dev/terraform-controller/controllers/configuration"
+	"github.com/oam-dev/terraform-controller/controllers/configuration/backend"
+	"github.com/oam-dev/terraform-controller/controllers/features"
 	"github.com/oam-dev/terraform-controller/controllers/provider"
 	"github.com/oam-dev/terraform-controller/controllers/terraform"
 )

--- a/controllers/configuration_controller.go
+++ b/controllers/configuration_controller.go
@@ -410,9 +410,9 @@ func (r *ConfigurationReconciler) terraformDestroy(ctx context.Context, configur
 	// - Configuration is deletable (no cloud resources are provisioned or force delete is set) WHEN not allow to delete halfway.
 	// - OR user want to keep the resource when delete the configuration CR
 	// If allowed to delete halfway, there could be parts of cloud resources are provisioned, so we need to wait destroy job is done.
-	notWaitingDestroyJob := deletable && !feature.DefaultFeatureGate.Enabled(features.AllowDeleteHalfway) || !meta.DeleteResource
-	// If the configuration is deletable, and it is caused by AllowDeleteHalfway feature, the apply job may be still running, we should clean it first to avoid data race.
-	needCleanApplyJob := deletable && feature.DefaultFeatureGate.Enabled(features.AllowDeleteHalfway)
+	notWaitingDestroyJob := deletable && !feature.DefaultFeatureGate.Enabled(features.AllowDeleteProvisioningResource) || !meta.DeleteResource
+	// If the configuration is deletable, and it is caused by AllowDeleteProvisioningResource feature, the apply job may be still running, we should clean it first to avoid data race.
+	needCleanApplyJob := deletable && feature.DefaultFeatureGate.Enabled(features.AllowDeleteProvisioningResource)
 
 	if !notWaitingDestroyJob {
 		if needCleanApplyJob {

--- a/controllers/features/feature_gate.go
+++ b/controllers/features/feature_gate.go
@@ -1,0 +1,35 @@
+/*
+Copyright 2023 The KubeVela Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package features
+
+import (
+	"k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/apiserver/pkg/util/feature"
+	"k8s.io/component-base/featuregate"
+)
+
+const (
+	AllowDeleteHalfway featuregate.Feature = "AllowDeleteHalfway"
+)
+
+var defaultFeatureGates = map[featuregate.Feature]featuregate.FeatureSpec{
+	AllowDeleteHalfway: {Default: false, PreRelease: featuregate.Alpha},
+}
+
+func init() {
+	runtime.Must(feature.DefaultMutableFeatureGate.Add(defaultFeatureGates))
+}

--- a/controllers/features/feature_gate.go
+++ b/controllers/features/feature_gate.go
@@ -23,11 +23,11 @@ import (
 )
 
 const (
-	AllowDeleteHalfway featuregate.Feature = "AllowDeleteHalfway"
+	AllowDeleteProvisioningResource featuregate.Feature = "AllowDeleteProvisioningResource"
 )
 
 var defaultFeatureGates = map[featuregate.Feature]featuregate.FeatureSpec{
-	AllowDeleteHalfway: {Default: false, PreRelease: featuregate.Alpha},
+	AllowDeleteProvisioningResource: {Default: false, PreRelease: featuregate.Alpha},
 }
 
 func init() {

--- a/controllers/terraform/status.go
+++ b/controllers/terraform/status.go
@@ -35,6 +35,7 @@ func GetTerraformStatus(ctx context.Context, jobNamespace, jobName, containerNam
 	return state, errors.New(errMsg)
 }
 
+// analyzeTerraformLog will analyze the logs of Terraform apply pod, returns true if check is ok.
 func analyzeTerraformLog(logs string, stage types.Stage) (bool, types.ConfigurationState, string) {
 	lines := strings.Split(logs, "\n")
 	for i, line := range lines {

--- a/e2e/normal/configuration_test.go
+++ b/e2e/normal/configuration_test.go
@@ -91,17 +91,6 @@ func testBase(t *testing.T, configuration ConfigurationAttr, injector Injector, 
 			}
 			output, err = exec.Command("bash", "-c", "kubectl get pod").CombinedOutput()
 			lines = strings.Split(string(output), "\n")
-			for _, line := range lines {
-				fields = strings.Fields(line)
-				if len(fields) == 0 {
-					continue
-				}
-				if strings.HasPrefix(fields[0], "random-e2e-git-creds-secret-ref-apply") {
-					output, _ = exec.Command("bash", "-c", fmt.Sprintf("kubectl get pod -o yaml %s", fields[0])).CombinedOutput()
-					t.Log(string(output))
-				}
-			}
-			assert.NilError(t, err)
 			t.Log(string(output))
 			if i == 119 {
 				t.Error("Configuration is not ready")

--- a/e2e/normal/configuration_test.go
+++ b/e2e/normal/configuration_test.go
@@ -31,9 +31,10 @@ var (
 		"examples/alibaba/eip/configuration_eip_remote_subdirectory.yaml",
 		"examples/alibaba/oss/configuration_hcl_bucket.yaml",
 	}
-	testConfigurationsForceDelete             = "examples/random/configuration_force_delete.yaml"
-	testConfigurationsGitCredsSecretReference = "../examples/random/configuration_git_ssh.yaml"
-	chartNamespace                            = "terraform"
+	testConfigurationsForceDelete                = "examples/random/configuration_force_delete.yaml"
+	testConfigurationsGitCredsSecretReference    = "examples/random/configuration_git_ssh.yaml"
+	testConfigurationDeleteProvisioningResources = "examples/random/configuration_delete_provisioning_resources.yaml"
+	chartNamespace                               = "terraform"
 )
 
 type ConfigurationAttr struct {
@@ -57,7 +58,9 @@ type DoFunc = func(ctx *TestContext)
 
 type Injector struct {
 	BeforeApplyConfiguration DoFunc
+	CheckConfiguration       DoFunc
 	CleanUp                  DoFunc
+
 	// add more actions and check points if needed
 }
 
@@ -69,6 +72,43 @@ func invoke(do DoFunc, ctx *TestContext) {
 
 func testBase(t *testing.T, configuration ConfigurationAttr, injector Injector, useCustomBackend bool) {
 	klog.Infof("%s test begins……", configuration.Name)
+
+	waitConfigurationAvailable := func(ctx *TestContext) {
+		for i := 0; i < 120; i++ {
+			var fields []string
+			output, err := exec.Command("bash", "-c", "kubectl get configuration").CombinedOutput()
+			assert.NilError(t, err)
+
+			lines := strings.Split(string(output), "\n")
+			for i, line := range lines {
+				if i == 0 {
+					continue
+				}
+				fields = strings.Fields(line)
+				if len(fields) == 3 && fields[0] == configuration.Name && fields[1] == Available {
+					return
+				}
+			}
+			output, err = exec.Command("bash", "-c", "kubectl get pod").CombinedOutput()
+			lines = strings.Split(string(output), "\n")
+			for _, line := range lines {
+				fields = strings.Fields(line)
+				if len(fields) == 0 {
+					continue
+				}
+				if strings.HasPrefix(fields[0], "random-e2e-git-creds-secret-ref-apply") {
+					output, _ = exec.Command("bash", "-c", fmt.Sprintf("kubectl get pod -o yaml %s", fields[0])).CombinedOutput()
+					t.Log(string(output))
+				}
+			}
+			assert.NilError(t, err)
+			t.Log(string(output))
+			if i == 119 {
+				t.Error("Configuration is not ready")
+			}
+			time.Sleep(time.Second * 5)
+		}
+	}
 
 	backendSecretNamespace := configuration.BackendStateSecretNS
 	if backendSecretNamespace == "" {
@@ -94,34 +134,17 @@ func testBase(t *testing.T, configuration ConfigurationAttr, injector Injector, 
 	klog.Info("1. Applying Configuration")
 	invoke(injector.BeforeApplyConfiguration, testCtx)
 	pwd, _ := os.Getwd()
-	configuration.YamlPath = filepath.Join(pwd, "..", configuration.YamlPath)
+	configuration.YamlPath = filepath.Join(pwd, "../..", configuration.YamlPath)
 	cmd := fmt.Sprintf("kubectl apply -f %s", configuration.YamlPath)
-	err = exec.Command("bash", "-c", cmd).Start()
-	assert.NilError(t, err)
+	output, err := exec.Command("bash", "-c", cmd).CombinedOutput()
+	assert.NilError(t, err, string(output))
 
 	klog.Info("2. Checking Configuration status")
-	for i := 0; i < 120; i++ {
-		var fields []string
-		output, err := exec.Command("bash", "-c", "kubectl get configuration").Output()
-		assert.NilError(t, err)
-
-		lines := strings.Split(string(output), "\n")
-		for i, line := range lines {
-			if i == 0 {
-				continue
-			}
-			fields = strings.Fields(line)
-			if len(fields) == 3 && fields[0] == configuration.Name && fields[1] == Available {
-				goto continueCheck
-			}
-		}
-		if i == 119 {
-			t.Error("Configuration is not ready")
-		}
-		time.Sleep(time.Second * 5)
+	if injector.CheckConfiguration == nil {
+		injector.CheckConfiguration = waitConfigurationAvailable
 	}
+	invoke(injector.CheckConfiguration, testCtx)
 
-continueCheck:
 	klog.Info("3. Checking the status of Configs and Secrets")
 
 	klog.Info("- Checking ConfigMap which stores .tf")
@@ -134,9 +157,11 @@ continueCheck:
 		assert.NilError(t, err)
 	}
 
-	klog.Info("- Checking Secret which stores outputs")
-	_, err = clientSet.CoreV1().Secrets("default").Get(ctx, configuration.OutputsSecretName, v1.GetOptions{})
-	assert.NilError(t, err)
+	if configuration.OutputsSecretName != "" {
+		klog.Info("- Checking Secret which stores outputs")
+		_, err = clientSet.CoreV1().Secrets("default").Get(ctx, configuration.OutputsSecretName, v1.GetOptions{})
+		assert.NilError(t, err)
+	}
 
 	klog.Info("- Checking Secret which stores variables")
 	_, err = clientSet.CoreV1().Secrets("default").Get(ctx, configuration.VariableSecretName, v1.GetOptions{})
@@ -144,8 +169,8 @@ continueCheck:
 
 	klog.Info("4. Deleting Configuration")
 	cmd = fmt.Sprintf("kubectl delete -f %s", configuration.YamlPath)
-	err = exec.Command("bash", "-c", cmd).Start()
-	assert.NilError(t, err)
+	output, err = exec.Command("bash", "-c", cmd).CombinedOutput()
+	assert.NilError(t, err, string(output))
 
 	klog.Info("5. Checking Configuration is deleted")
 	for i := 0; i < 60; i++ {
@@ -153,8 +178,8 @@ continueCheck:
 			fields  []string
 			existed bool
 		)
-		output, err := exec.Command("bash", "-c", "kubectl get configuration").Output()
-		assert.NilError(t, err)
+		output, err := exec.Command("bash", "-c", "kubectl get configuration").CombinedOutput()
+		assert.NilError(t, err, string(output))
 
 		lines := strings.Split(string(output), "\n")
 
@@ -181,8 +206,10 @@ continueCheck:
 
 	klog.Info("6. Checking Secrets and ConfigMap which should all be deleted")
 
-	_, err = clientSet.CoreV1().Secrets("default").Get(ctx, configuration.OutputsSecretName, v1.GetOptions{})
-	assert.Equal(t, kerrors.IsNotFound(err), true)
+	if configuration.OutputsSecretName != "" {
+		_, err = clientSet.CoreV1().Secrets("default").Get(ctx, configuration.OutputsSecretName, v1.GetOptions{})
+		assert.Equal(t, kerrors.IsNotFound(err), true)
+	}
 
 	_, err = clientSet.CoreV1().Secrets("default").Get(ctx, configuration.VariableSecretName, v1.GetOptions{})
 	assert.Equal(t, kerrors.IsNotFound(err), true)
@@ -221,14 +248,14 @@ func TestInlineCredentialsConfigurationUseCustomBackendKubernetes(t *testing.T) 
 		VariableSecretName:     "variable-random-e2e-custom-backend-kubernetes",
 	}
 	beforeApply := func(ctx *TestContext) {
-		cmd := exec.Command("bash", "-c", "kubectl create ns a")
-		err := cmd.Run()
-		assert.NilError(t, err)
+		output, err := exec.Command("bash", "-c", "kubectl create ns a").CombinedOutput()
+		if err != nil && !strings.Contains(string(output), "already exists") {
+			assert.NilError(t, err, string(output))
+		}
 	}
 	cleanUp := func(ctx *TestContext) {
-		cmd := exec.Command("bash", "-c", "kubectl delete ns a")
-		err := cmd.Run()
-		assert.NilError(t, err)
+		output, err := exec.Command("bash", "-c", "kubectl delete ns a").CombinedOutput()
+		assert.NilError(t, err, string(output))
 	}
 	testBase(
 		t,
@@ -260,7 +287,7 @@ func TestForceDeleteConfiguration(t *testing.T) {
 			fields  []string
 			existed bool
 		)
-		output, err := exec.Command("bash", "-c", "kubectl get configuration").Output()
+		output, err := exec.Command("bash", "-c", "kubectl get configuration").CombinedOutput()
 		assert.NilError(t, err)
 
 		lines := strings.Split(string(output), "\n")
@@ -300,17 +327,19 @@ func TestGitCredentialsSecretReference(t *testing.T) {
 	clientSet, err := client.Init()
 	assert.NilError(t, err)
 	pwd, _ := os.Getwd()
-	gitServer := filepath.Join(pwd, "..", "../examples/git-credentials")
+	gitServer := filepath.Join(pwd, "../..", "examples/git-credentials")
 	gitServerApplyCmd := fmt.Sprintf("kubectl apply -f %s", gitServer)
 	gitServerDeleteCmd := fmt.Sprintf("kubectl delete -f %s", gitServer)
 	gitSshAuthSecretYaml := filepath.Join(gitServer, "git-ssh-auth-secret.yaml")
 
 	beforeApply := func(ctx *TestContext) {
-		err = exec.Command("bash", "-c", gitServerApplyCmd).Run()
-		assert.NilError(t, err)
+		output, err := exec.Command("bash", "-c", gitServerApplyCmd).CombinedOutput()
+		assert.NilError(t, err, string(output))
 
 		klog.Info("- Checking git-server pod status")
 		for i := 0; i < 120; i++ {
+			serverReady := false
+			pushReady := false
 			pod, _ := clientSet.CoreV1().Pods("default").Get(ctx, "git-server", v1.GetOptions{})
 			conditions := pod.Status.Conditions
 			var index int
@@ -322,6 +351,13 @@ func TestGitCredentialsSecretReference(t *testing.T) {
 				}
 			}
 			if conditions[index].Status == "True" && conditions[index].Type == coreV1.PodReady {
+				serverReady = true
+			}
+			job, _ := clientSet.BatchV1().Jobs("default").Get(ctx, "git-push", v1.GetOptions{})
+			if job.Status.Succeeded == 1 {
+				pushReady = true
+			}
+			if serverReady && pushReady {
 				break
 			}
 			if i == 119 {
@@ -331,7 +367,7 @@ func TestGitCredentialsSecretReference(t *testing.T) {
 		}
 
 		getKnownHostsCmd := "kubectl exec pod/git-server -- ssh-keyscan git-server"
-		knownHosts, err := exec.Command("bash", "-c", getKnownHostsCmd).Output()
+		knownHosts, err := exec.Command("bash", "-c", getKnownHostsCmd).CombinedOutput()
 		assert.NilError(t, err)
 
 		gitSshAuthSecretTmpl := filepath.Join(gitServer, "templates/git-ssh-auth-secret.tmpl")
@@ -360,6 +396,63 @@ func TestGitCredentialsSecretReference(t *testing.T) {
 		},
 		false,
 	)
+}
+
+func TestAllowDeleteProvisioningResoruce(t *testing.T) {
+	configuration := ConfigurationAttr{
+		Name:                   "random-e2e-delete-provisioning-resources",
+		YamlPath:               testConfigurationDeleteProvisioningResources,
+		TFConfigMapName:        "tf-random-e2e-delete-provisioning-resources",
+		BackendStateSecretName: "tfstate-default-random-e2e-delete-provisioning-resources",
+		// won't generate output at all
+		OutputsSecretName:  "",
+		VariableSecretName: "variable-random-e2e-delete-provisioning-resources",
+	}
+	checkConfigurationIsProvisioning := func(ctx *TestContext) {
+
+		for i := 0; i < 20; i++ {
+			cfgProvisioning := false
+			backendExist := false
+			klog.Info("Check configuration is provisioning")
+			var fields []string
+			output, err := exec.Command("bash", "-c", "kubectl get configuration").CombinedOutput()
+			assert.NilError(t, err)
+
+			lines := strings.Split(string(output), "\n")
+			for i, line := range lines {
+				if i == 0 {
+					continue
+				}
+				fields = strings.Fields(line)
+				if len(fields) == 3 && fields[0] == configuration.Name && fields[1] == Provisioning {
+					cfgProvisioning = true
+				}
+			}
+			_, err = ctx.ClientSet.CoreV1().Secrets(ctx.BackendSecretNamespace).Get(ctx, configuration.BackendStateSecretName, v1.GetOptions{})
+			if err == nil {
+				backendExist = true
+			}
+
+			if cfgProvisioning && backendExist {
+				return
+			}
+
+			if i == 119 {
+				t.Error("Configuration is not ready")
+			}
+			time.Sleep(time.Second * 5)
+		}
+
+	}
+	testBase(
+		t,
+		configuration,
+		Injector{
+			CheckConfiguration: checkConfigurationIsProvisioning,
+		},
+		false,
+	)
+
 }
 
 //func TestBasicConfigurationRegression(t *testing.T) {

--- a/e2e/normal/regression.go
+++ b/e2e/normal/regression.go
@@ -15,6 +15,7 @@ import (
 
 // Available is the available status of Configuration
 const Available = "Available"
+const Provisioning = "ProvisioningAndChecking"
 
 // Regression test for the e2e.
 func Regression(t *testing.T, testcases []string, retryTimes int) {

--- a/examples/random/configuration_delete_provisioning_resources.yaml
+++ b/examples/random/configuration_delete_provisioning_resources.yaml
@@ -1,0 +1,18 @@
+apiVersion: terraform.core.oam.dev/v1beta2
+kind: Configuration
+metadata:
+  name: random-e2e-delete-provisioning-resources
+spec:
+  hcl: |
+    resource "random_id" "server" {
+      byte_length = 8
+    }
+    resource "random_id" "error" {
+      byte_length = -1
+    }
+
+  inlineCredentials: true
+
+  writeConnectionSecretToRef:
+    name: random-conn
+    namespace: default

--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/onsi/ginkgo v1.16.4
 	github.com/onsi/gomega v1.19.0
 	github.com/pkg/errors v0.9.1
+	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.7.0
 	gopkg.in/yaml.v2 v2.4.0
 	gotest.tools v2.2.0+incompatible
@@ -63,7 +64,6 @@ require (
 	github.com/prometheus/client_model v0.2.0 // indirect
 	github.com/prometheus/common v0.26.0 // indirect
 	github.com/prometheus/procfs v0.6.0 // indirect
-	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/zclconf/go-cty v1.10.0 // indirect
 	golang.org/x/net v0.2.0 // indirect
 	golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d // indirect

--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,9 @@ require (
 	gotest.tools v2.2.0+incompatible
 	k8s.io/api v0.21.3
 	k8s.io/apimachinery v0.21.3
+	k8s.io/apiserver v0.21.3
 	k8s.io/client-go v0.21.3
+	k8s.io/component-base v0.21.3
 	k8s.io/klog/v2 v2.8.0
 	k8s.io/utils v0.0.0-20210722164352-7f3ee0f31471
 	sigs.k8s.io/controller-runtime v0.9.5
@@ -77,7 +79,6 @@ require (
 	gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7 // indirect
 	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect
 	k8s.io/apiextensions-apiserver v0.21.3 // indirect
-	k8s.io/component-base v0.21.3 // indirect
 	k8s.io/kube-openapi v0.0.0-20210305001622-591a79e4bda7 // indirect
 	sigs.k8s.io/structured-merge-diff/v4 v4.1.2 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -799,6 +799,7 @@ k8s.io/apiextensions-apiserver v0.21.3 h1:+B6biyUWpqt41kz5x6peIsljlsuwvNAp/oFax/
 k8s.io/apiextensions-apiserver v0.21.3/go.mod h1:kl6dap3Gd45+21Jnh6utCx8Z2xxLm8LGDkprcd+KbsE=
 k8s.io/apimachinery v0.21.3 h1:3Ju4nvjCngxxMYby0BimUk+pQHPOQp3eCGChk5kfVII=
 k8s.io/apimachinery v0.21.3/go.mod h1:H/IM+5vH9kZRNJ4l3x/fXP/5bOPJaVP/guptnZPeCFI=
+k8s.io/apiserver v0.21.3 h1:QxAgE1ZPQG5cPlHScHTnLxP9H/kU3zjH1Vnd8G+n5OI=
 k8s.io/apiserver v0.21.3/go.mod h1:eDPWlZG6/cCCMj/JBcEpDoK+I+6i3r9GsChYBHSbAzU=
 k8s.io/client-go v0.21.3 h1:J9nxZTOmvkInRDCzcSNQmPJbDYN/PjlxXT9Mos3HcLg=
 k8s.io/client-go v0.21.3/go.mod h1:+VPhCgTsaFmGILxR/7E1N0S+ryO010QBeNCv5JwRGYU=

--- a/hack/tool/validation/tf_validation_backend/go.sum
+++ b/hack/tool/validation/tf_validation_backend/go.sum
@@ -1,4 +1,3 @@
-github.com/agext/levenshtein v1.2.1 h1:QmvMAjj2aEICytGiWzmxoE0x2KZvE0fvmqMOfy2tjT8=
 github.com/agext/levenshtein v1.2.1/go.mod h1:JEDfjyjHDjOF/1e4FlBE/PkbqA9OfWu2ki2W0IB5558=
 github.com/agext/levenshtein v1.2.3 h1:YB2fHEn0UJagG8T1rrWknE3ZQzWM06O8AMAatNn7lmo=
 github.com/agext/levenshtein v1.2.3/go.mod h1:JEDfjyjHDjOF/1e4FlBE/PkbqA9OfWu2ki2W0IB5558=
@@ -14,7 +13,6 @@ github.com/go-test/deep v1.0.3/go.mod h1:wGDj63lr65AM2AQyKZd/NYHGb0R+1RLqB8NKt3a
 github.com/golang/protobuf v1.1.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.3.1/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.3.4/go.mod h1:vzj43D7+SQXF/4pzW/hwtAqwc6iTitCiVSaWz5lYuqw=
-github.com/google/go-cmp v0.3.1 h1:Xye71clBPdm5HgqGwUkwhbynsUJZhDbS20FvLhQ2izg=
 github.com/google/go-cmp v0.3.1/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
 github.com/google/go-cmp v0.5.7 h1:81/ik6ipDQS2aGcBfIN5dHDB36BwrStyeAQquSYCV4o=
 github.com/google/go-cmp v0.5.7/go.mod h1:n+brtR0CgQNWTVd5ZUFpTBC8YFBDLK/h/bpaJ8/DtOE=
@@ -27,7 +25,6 @@ github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/kylelemons/godebug v0.0.0-20170820004349-d65d576e9348 h1:MtvEpTB6LX3vkb4ax0b5D2DHbNAUsen0Gx5wZoq3lV4=
 github.com/kylelemons/godebug v0.0.0-20170820004349-d65d576e9348/go.mod h1:B69LEHPfb2qLo0BaaOLcbitczOKLWTsrBG9LczfCD4k=
-github.com/mitchellh/go-wordwrap v0.0.0-20150314170334-ad45545899c7 h1:DpOJ2HYzCv8LZP15IdmG+YdwD2luVPHITV96TkirNBM=
 github.com/mitchellh/go-wordwrap v0.0.0-20150314170334-ad45545899c7/go.mod h1:ZXFpozHsX6DPmq2I0TCekCxypsnAUbP2oI0UX1GXzOo=
 github.com/mitchellh/go-wordwrap v1.0.1 h1:TLuKupo69TCn6TQSyGxwI1EblZZEsQ0vMlAFQflz0v0=
 github.com/mitchellh/go-wordwrap v1.0.1/go.mod h1:R62XHJLzvMFRBbcrT7m7WgmE1eOyTSsCt+hzestvNj0=
@@ -40,7 +37,6 @@ github.com/vmihailenco/msgpack v3.3.3+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6Ac
 github.com/vmihailenco/msgpack/v4 v4.3.12/go.mod h1:gborTTJjAo/GWTqqRjrLCn9pgNN+NXzzngzBKDPIqw4=
 github.com/vmihailenco/tagparser v0.1.1/go.mod h1:OeAg3pn3UbLjkWt+rN9oFYB6u/cQgqMEUPoW2WPyhdI=
 github.com/zclconf/go-cty v1.2.0/go.mod h1:hOPWgoHbaTUnI5k4D2ld+GRpFJSCe6bCM7m1q/N4PQ8=
-github.com/zclconf/go-cty v1.8.0 h1:s4AvqaeQzJIu3ndv4gVIhplVD0krU+bgrcLSVUnaWuA=
 github.com/zclconf/go-cty v1.8.0/go.mod h1:vVKLxnk3puL4qRAv72AO+W99LUD4da90g3uUAzyuvAk=
 github.com/zclconf/go-cty v1.10.0 h1:mp9ZXQeIcN8kAwuqorjH+Q+njbJKjLrvB2yIh4q7U+0=
 github.com/zclconf/go-cty v1.10.0/go.mod h1:vVKLxnk3puL4qRAv72AO+W99LUD4da90g3uUAzyuvAk=
@@ -57,11 +53,11 @@ golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20190502175342-a43fa875dd82/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.2/go.mod h1:bEr9sfX3Q8Zfm5fL9x+3itogRgK3+ptLWKqgva+5dAk=
-golang.org/x/text v0.3.5 h1:i6eZZ+zk0SOf0xgBpEpPD18qWcJda6q1sxt3S0kzyUQ=
 golang.org/x/text v0.3.5/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
 golang.org/x/text v0.3.7 h1:olpwvP2KacW1ZWvsR7uQhoyTYvKAupfQrRGBFM352Gk=
 golang.org/x/text v0.3.7/go.mod h1:u+2+/6zg+i71rQMx5EYifcz6MCKuco9NR6JIITiCfzQ=
 golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
+golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IVDexMakfv52eLZ2CXBWiKr4=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 google.golang.org/appengine v1.1.0/go.mod h1:EbEs0AVv82hx2wNQdGPgUI5lhzA/G0D9YwlJXL52JkM=
 google.golang.org/appengine v1.6.5/go.mod h1:8WjMMxjGQR8xUklV/ARdw2HLXBOI7O7uCIDZVag1xfc=

--- a/main.go
+++ b/main.go
@@ -17,10 +17,11 @@ limitations under the License.
 package main
 
 import (
-	"flag"
+	"k8s.io/apiserver/pkg/util/feature"
 	"os"
 	"time"
 
+	"github.com/spf13/pflag"
 	"k8s.io/apimachinery/pkg/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/klog/v2"
@@ -52,15 +53,16 @@ func main() {
 	var namespace string
 	var controllerNamespace string
 
-	flag.BoolVar(&enableLeaderElection, "enable-leader-election", false, "Enable leader election for controller manager, this will ensure there is only one active controller manager.")
-	flag.DurationVar(&syncPeriod, "informer-re-sync-interval", 10*time.Second, "controller shared informer lister full re-sync period")
-	flag.StringVar(&metricsAddr, "metrics-addr", ":38080", "The address the metric endpoint binds to.")
-	flag.StringVar(&namespace, "namespace", "", "Namespace to watch for resources, defaults to all namespaces")
-	flag.StringVar(&controllerNamespace, "controller-namespace", "", "Namespace to run the terraform jobs")
+	pflag.BoolVar(&enableLeaderElection, "enable-leader-election", false, "Enable leader election for controller manager, this will ensure there is only one active controller manager.")
+	pflag.DurationVar(&syncPeriod, "informer-re-sync-interval", 10*time.Second, "controller shared informer lister full re-sync period")
+	pflag.StringVar(&metricsAddr, "metrics-addr", ":38080", "The address the metric endpoint binds to.")
+	pflag.StringVar(&namespace, "namespace", "", "Namespace to watch for resources, defaults to all namespaces")
+	pflag.StringVar(&controllerNamespace, "controller-namespace", "", "Namespace to run the terraform jobs")
+	feature.DefaultMutableFeatureGate.AddFlag(pflag.CommandLine)
 
 	// embed klog
 	klog.InitFlags(nil)
-	flag.Parse()
+	pflag.Parse()
 
 	ctrl.SetLogger(klogr.New())
 

--- a/main.go
+++ b/main.go
@@ -17,12 +17,12 @@ limitations under the License.
 package main
 
 import (
-	"k8s.io/apiserver/pkg/util/feature"
 	"os"
 	"time"
 
 	"github.com/spf13/pflag"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apiserver/pkg/util/feature"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/klog/v2"
 	"k8s.io/klog/v2/klogr"


### PR DESCRIPTION
Signed-off-by: Qiaozp <qiaozhongpei.qzp@alibaba-inc.com>

Add a feature gate: `AllowDeleteProvisioningResource`. When enabled, controller will allow to delete Configuration in the state of `ProvisioningAndChecking`. This is useful when developing new configuration. 

Here's some examples. 

- When apply a large Configuration which creates more than one cloud resource, it could fail to create all resources but some of resources have been created. 
- When we apply a Configuration and it fails somehow. (Like the API has been changed by vendor)

Before, we have no method to delete this Configuration other than delete the `finalizer` fields manually and delete the created resources on vendor's console, which is tedious and annoying. 

Now created resource can be deleted by controller automatically.