### PR TITLE
ISSUE-376: Removing the condition that looks for outputs in tfstate to decide if tfstate is generated or not

### DIFF
--- a/controllers/configuration_controller.go
+++ b/controllers/configuration_controller.go
@@ -1145,16 +1145,8 @@ func (meta *TFConfigurationMeta) isTFStateGenerated(ctx context.Context) bool {
 		return false
 	}
 	// 2. and exist tfstate file
-	tfStateJSON, err := meta.Backend.GetTFStateJSON(ctx)
-	if err != nil {
-		return false
-	}
-	// 3. and outputs not empty
-	var tfState TFState
-	if err = json.Unmarshal(tfStateJSON, &tfState); err != nil {
-		return false
-	}
-	return len(tfState.Outputs) > 0
+	_, err := meta.Backend.GetTFStateJSON(ctx)
+	return err == nil
 }
 
 //nolint:funlen

--- a/controllers/configuration_controller_test.go
+++ b/controllers/configuration_controller_test.go
@@ -2029,7 +2029,7 @@ func TestIsTFStateGenerated(t *testing.T) {
 				meta:      meta3,
 			},
 			want: want{
-				generated: false,
+				generated: true,
 			},
 		},
 		"outputs in the backend secret are not empty": {


### PR DESCRIPTION
This PR is to fix [this](https://github.com/kubevela/terraform-controller/issues/376) issue.

Terraform scripts should be treated valid even without outputs.