### PR TITLE
Chore: replace deprecated command with environment file

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,11 +29,12 @@ jobs:
         id: get_release
         uses: bruceadams/get-release@v1.2.2
       - name: Get matrix
-        id: get_matrix
+        id: get_matri
+        shell: bash
         run: |
           TARGETS=${{matrix.TARGETS}}
-          echo ::set-output name=OS::${TARGETS%/*}
-          echo ::set-output name=ARCH::${TARGETS#*/}
+          echo "OS=${TARGETS%/*}" >> $GITHUB_OUTPUT
+          echo "ARCH=${TARGETS#*/}" >> $GITHUB_OUTPUT
       - name: Get ldflags
         id: get_ldflags
         run: |


### PR DESCRIPTION
## Description

Closes #384 

Update `.github/workflows/release.yml` to use environment file instead of deprecated `set-output` command. 
For more information, see: [https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/)

I found the workflow file that use `set-output` command through the following command:

```bash
$ find . -name '*.yml' -o -name '*.yaml' | xargs egrep '\bset-output\b'
```

**AS-IS**

```yaml
- name: Get matrix
  id: get_matrix
  run: |
    TARGETS=${{matrix.TARGETS}}
    echo ::set-output name=OS::${TARGETS%/*}
    echo ::set-output name=ARCH::${TARGETS#*/}
```

**TO-BE**

```yaml
- name: Get matrix
  id: get_matri
  shell: bash
  run: |
    TARGETS=${{matrix.TARGETS}}
    echo "OS=${TARGETS%/*}" >> $GITHUB_OUTPUT
    echo "ARCH=${TARGETS#*/}" >> $GITHUB_OUTPUT
```