### PR TITLE
Add Git credential volume mount to apply container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,6 +27,6 @@ COPY --from=builder /workspace/manager .
 # COPY terraform binary
 COPY bin/terraform /usr/bin/terraform
 #RUN chmod +x /usr/bin/terraform
-RUN apk add git
+RUN apk add git openssh
 
 ENTRYPOINT ["/manager"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,4 +28,5 @@ COPY --from=builder /workspace/manager .
 COPY bin/terraform /usr/bin/terraform
 #RUN chmod +x /usr/bin/terraform
 RUN apk add git
+
 ENTRYPOINT ["/manager"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,6 +27,5 @@ COPY --from=builder /workspace/manager .
 # COPY terraform binary
 COPY bin/terraform /usr/bin/terraform
 #RUN chmod +x /usr/bin/terraform
-RUN apk add git openssh
-
+RUN apk add git
 ENTRYPOINT ["/manager"]

--- a/controllers/process/container/init.go
+++ b/controllers/process/container/init.go
@@ -37,6 +37,14 @@ func (a *Assembler) InitContainer() v1.Container {
 			})
 	}
 
+	if a.GitCredential {
+		mounts = append(mounts,
+			v1.VolumeMount{
+				Name:      types.GitAuthConfigVolumeName,
+				MountPath: types.GitAuthConfigVolumeMountPath,
+			})
+	}
+
 	c := v1.Container{
 		Name:            types.TerraformInitContainerName,
 		Image:           a.TerraformImage,

--- a/controllers/process/container/init.go
+++ b/controllers/process/container/init.go
@@ -49,13 +49,27 @@ func (a *Assembler) InitContainer() v1.Container {
 		Name:            types.TerraformInitContainerName,
 		Image:           a.TerraformImage,
 		ImagePullPolicy: v1.PullIfNotPresent,
-		Command: []string{
-			"sh",
-			"-c",
-			"terraform init",
-		},
+		Command: a.getInitCommand(),
 		VolumeMounts: mounts,
 		Env:          a.Envs,
 	}
 	return c
+}
+
+// getInitCommand dynamically builds the terraform init command, injecting the SSH agent if needed.
+func (a *Assembler) getInitCommand() []string {
+	cmd := "terraform init"
+
+	// If Git credentials exist, start the ssh-agent and add the key BEFORE running terraform init
+	if a.GitCredential {
+		sshCommand := fmt.Sprintf("eval `ssh-agent` && ssh-add %s/%s", types.GitAuthConfigVolumeMountPath, v1.SSHAuthPrivateKey)
+		cmd = fmt.Sprintf("%s && %s", sshCommand, cmd)
+	}
+
+	command := []string{
+		"sh",
+		"-c",
+		cmd,
+	}
+	return command
 }

--- a/controllers/process/container/init.go
+++ b/controllers/process/container/init.go
@@ -1,6 +1,8 @@
 package container
 
 import (
+	"fmt"
+	
 	"github.com/oam-dev/terraform-controller/api/types"
 	v1 "k8s.io/api/core/v1"
 )


### PR DESCRIPTION
If the cloned Terraform module has remote references that need Git credentials, Git credential volume mount to apply container is necessary.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Mounts the Git credential volume and switches Terraform init to a dynamic command (`getInitCommand`) that starts an SSH agent and adds the mounted key when Git auth is required. This lets Terraform init pull modules from private Git remotes without failing.

- **Dependencies**
  - Reverted `openssh` installation; image installs `git` only.

<sup>Written for commit 3d348df8fcd2f93b05aecb1802e82e79da1e5942. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kubevela/terraform-controller/pull/399?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

