### PR TITLE
fix: mask sensitive terraform outputs in Configuration status (#82)

### DIFF
--- a/api/v1beta2/configuration_types.go
+++ b/api/v1beta2/configuration_types.go
@@ -124,6 +124,11 @@ type ConfigurationDestroyStatus struct {
 // Property is the property for an output
 type Property struct {
 	Value string `json:"value,omitempty"`
+	// Sensitive indicates that this output was declared with `sensitive = true` in Terraform.
+	// When true, Value contains the placeholder string "[sensitive]" rather than the real value.
+	// The actual value is always written to the Secret referenced by WriteConnectionSecretToReference.
+	// +optional
+	Sensitive bool `json:"sensitive,omitempty"`
 }
 
 // Backend describes the Terraform backend configuration

--- a/chart/crds/terraform.core.oam.dev_configurations.yaml
+++ b/chart/crds/terraform.core.oam.dev_configurations.yaml
@@ -460,6 +460,12 @@ spec:
                     additionalProperties:
                       description: Property is the property for an output
                       properties:
+                        sensitive:
+                          description: |-
+                            Sensitive indicates that this output was declared with `sensitive = true` in Terraform.
+                            When true, Value contains the placeholder string "[sensitive]" rather than the real value.
+                            The actual value is always written to the Secret referenced by WriteConnectionSecretToReference.
+                          type: boolean
                         value:
                           type: string
                       type: object

--- a/controllers/features/feature_gate.go
+++ b/controllers/features/feature_gate.go
@@ -24,10 +24,18 @@ import (
 
 const (
 	AllowDeleteProvisioningResource featuregate.Feature = "AllowDeleteProvisioningResource"
+
+	// MaskSensitiveOutputs controls whether Terraform outputs marked `sensitive = true`
+	// are redacted in the Configuration custom resource status.
+	// When enabled (default), status.apply.outputs[key].value shows "[sensitive]" and
+	// the real value is written exclusively to the WriteConnectionSecret.
+	// Disable with --feature-gates=MaskSensitiveOutputs=false to restore legacy behavior.
+	MaskSensitiveOutputs featuregate.Feature = "MaskSensitiveOutputs"
 )
 
 var defaultFeatureGates = map[featuregate.Feature]featuregate.FeatureSpec{
 	AllowDeleteProvisioningResource: {Default: false, PreRelease: featuregate.Alpha},
+	MaskSensitiveOutputs:            {Default: true, PreRelease: featuregate.Beta},
 }
 
 func init() {

--- a/controllers/process/meta.go
+++ b/controllers/process/meta.go
@@ -78,6 +78,10 @@ type TFState struct {
 type TfStateProperty struct {
 	Value interface{} `json:"value,omitempty"`
 	Type  interface{} `json:"type,omitempty"`
+	// Sensitive indicates that this output was declared with `sensitive = true` in Terraform.
+	// When true, the real value is stored only in the WriteConnectionSecret; the Configuration
+	// status will show a placeholder instead.
+	Sensitive bool `json:"sensitive,omitempty"`
 }
 
 // ToProperty converts TfStateProperty type to Property
@@ -91,7 +95,8 @@ func (tp *TfStateProperty) ToProperty() (v1beta2.Property, error) {
 		return property, errors.Wrapf(err, "failed to convert value %s of terraform state outputs to string", tp.Value)
 	}
 	property = v1beta2.Property{
-		Value: sv,
+		Value:     sv,
+		Sensitive: tp.Sensitive,
 	}
 	return property, err
 }

--- a/controllers/process/process.go
+++ b/controllers/process/process.go
@@ -24,11 +24,18 @@ import (
 	"github.com/oam-dev/terraform-controller/api/v1beta2"
 	tfcfg "github.com/oam-dev/terraform-controller/controllers/configuration"
 	"github.com/oam-dev/terraform-controller/controllers/configuration/backend"
+	"github.com/oam-dev/terraform-controller/controllers/features"
 	"github.com/oam-dev/terraform-controller/controllers/provider"
 	"github.com/oam-dev/terraform-controller/controllers/util"
+	"k8s.io/apiserver/pkg/util/feature"
 )
 
 type Option func(spec v1beta2.Configuration, meta *TFConfigurationMeta)
+
+// SensitiveOutputPlaceholder is the string written to status.apply.outputs[key].value
+// when an output is marked `sensitive = true` in Terraform and the MaskSensitiveOutputs
+// feature gate is enabled. The real value is stored exclusively in the WriteConnectionSecret.
+const SensitiveOutputPlaceholder = "[sensitive]"
 
 // ControllerNamespaceOption will set the controller namespace for TFConfigurationMeta
 func ControllerNamespaceOption(controllerNamespace string) Option {
@@ -468,6 +475,9 @@ func (meta *TFConfigurationMeta) getTFOutputs(ctx context.Context, k8sClient cli
 	if err := json.Unmarshal(tfStateJSON, &tfState); err != nil {
 		return nil, err
 	}
+
+	// outputs holds the real (unredacted) values and is used to populate the
+	// WriteConnectionSecret so that sensitive values remain retrievable.
 	outputs := make(map[string]v1beta2.Property)
 	for k, v := range tfState.Outputs {
 		property, err := v.ToProperty()
@@ -476,9 +486,36 @@ func (meta *TFConfigurationMeta) getTFOutputs(ctx context.Context, k8sClient cli
 		}
 		outputs[k] = property
 	}
+
+	// statusOutputs is what gets written to status.apply.outputs.
+	// When MaskSensitiveOutputs is enabled (the default), any output with
+	// Sensitive=true is replaced with the placeholder string so that the real
+	// value is never exposed in the Configuration CR.
+	statusOutputs := make(map[string]v1beta2.Property)
+	if feature.DefaultFeatureGate.Enabled(features.MaskSensitiveOutputs) {
+		for k, v := range outputs {
+			if v.Sensitive {
+				klog.V(2).InfoS("Redacting sensitive output from Configuration status. "+
+					"The real value is available in the WriteConnectionSecret.",
+					"output", k, "configuration", configuration.Name, "namespace", configuration.Namespace)
+				statusOutputs[k] = v1beta2.Property{
+					Value:     SensitiveOutputPlaceholder,
+					Sensitive: true,
+				}
+			} else {
+				statusOutputs[k] = v
+			}
+		}
+	} else {
+		// Feature disabled: legacy behavior — expose all values in status.
+		for k, v := range outputs {
+			statusOutputs[k] = v
+		}
+	}
+
 	writeConnectionSecretToReference := configuration.Spec.WriteConnectionSecretToReference
 	if writeConnectionSecretToReference == nil || writeConnectionSecretToReference.Name == "" {
-		return outputs, nil
+		return statusOutputs, nil
 	}
 
 	name := writeConnectionSecretToReference.Name
@@ -486,6 +523,7 @@ func (meta *TFConfigurationMeta) getTFOutputs(ctx context.Context, k8sClient cli
 	if ns == "" {
 		ns = types.DefaultNamespace
 	}
+	// Always write the real (unredacted) values to the Secret, regardless of the feature gate.
 	data := make(map[string][]byte)
 	for k, v := range outputs {
 		data[k] = []byte(v.Value)
@@ -535,7 +573,7 @@ func (meta *TFConfigurationMeta) getTFOutputs(ctx context.Context, k8sClient cli
 			return nil, err
 		}
 	}
-	return outputs, nil
+	return statusOutputs, nil
 }
 
 func (meta *TFConfigurationMeta) PrepareTFVariables(configuration *v1beta2.Configuration) error {

--- a/controllers/process/process_test.go
+++ b/controllers/process/process_test.go
@@ -1,6 +1,8 @@
 package process
 
 import (
+	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/base64"
 	"encoding/json"
@@ -16,6 +18,7 @@ import (
 	"github.com/oam-dev/terraform-controller/api/v1beta1"
 	"github.com/oam-dev/terraform-controller/api/v1beta2"
 	"github.com/oam-dev/terraform-controller/controllers/configuration/backend"
+	"github.com/oam-dev/terraform-controller/controllers/features"
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 	batchv1 "k8s.io/api/batch/v1"
@@ -26,6 +29,8 @@ import (
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apiserver/pkg/util/feature"
+	featuretest "k8s.io/component-base/featuregate/testing"
 	"k8s.io/utils/pointer"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -859,6 +864,44 @@ func TestTfStatePropertyToToProperty(t *testing.T) {
 	}
 }
 
+// TestTfStatePropertyToPropertySensitive verifies that the Sensitive flag is
+// correctly captured from TfStateProperty and forwarded to the resulting Property.
+func TestTfStatePropertyToPropertySensitive(t *testing.T) {
+	testcases := []struct {
+		name          string
+		input         TfStateProperty
+		wantValue     string
+		wantSensitive bool
+	}{
+		{
+			name:          "non-sensitive string output",
+			input:         TfStateProperty{Value: "hello", Type: "string", Sensitive: false},
+			wantValue:     "hello",
+			wantSensitive: false,
+		},
+		{
+			name:          "sensitive string output",
+			input:         TfStateProperty{Value: "super-secret", Type: "string", Sensitive: true},
+			wantValue:     "super-secret",
+			wantSensitive: true,
+		},
+		{
+			name:          "sensitive integer output",
+			input:         TfStateProperty{Value: 42, Type: "number", Sensitive: true},
+			wantValue:     "42",
+			wantSensitive: true,
+		},
+	}
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			prop, err := tc.input.ToProperty()
+			assert.NoError(t, err)
+			assert.Equal(t, tc.wantValue, prop.Value)
+			assert.Equal(t, tc.wantSensitive, prop.Sensitive)
+		})
+	}
+}
+
 func TestIsTFStateGenerated(t *testing.T) {
 	type args struct {
 		ctx           context.Context
@@ -1377,6 +1420,111 @@ func TestGetTFOutputs(t *testing.T) {
 		})
 	}
 
+}
+
+// TestGetTFOutputsSensitiveMasking verifies that:
+//  1. When MaskSensitiveOutputs is enabled (default), sensitive outputs are
+//     redacted in the returned status map but written with real values to the Secret.
+//  2. When MaskSensitiveOutputs is disabled, all values pass through unchanged
+//     (legacy behavior).
+func TestGetTFOutputsSensitiveMasking(t *testing.T) {
+	ctx := context.Background()
+
+	// tfStateData encodes a state file containing one sensitive and one non-sensitive output.
+	// Equivalent JSON (before gzip+base64):
+	// {
+	//   "outputs": {
+	//     "public_ip":   {"value": "1.2.3.4",       "type": "string", "sensitive": false},
+	//     "db_password": {"value": "s3cr3t",        "type": "string", "sensitive": true}
+	//   }
+	// }
+	rawState := `{
+		"version": 4,
+		"terraform_version": "1.0.0",
+		"outputs": {
+			"public_ip":   {"value": "1.2.3.4", "type": "string", "sensitive": false},
+			"db_password": {"value": "s3cr3t",  "type": "string", "sensitive": true}
+		}
+	}`
+
+	var gzBuf bytes.Buffer
+	gzWriter := gzip.NewWriter(&gzBuf)
+	_, _ = gzWriter.Write([]byte(rawState))
+	_ = gzWriter.Close()
+	compressedState := base64.StdEncoding.EncodeToString(gzBuf.Bytes())
+	compressedStateBytes, _ := base64.StdEncoding.DecodeString(compressedState)
+
+	tfStateSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "tfstate-default-sensitive-test",
+			Namespace: "default",
+		},
+		Type: corev1.SecretTypeOpaque,
+		Data: map[string][]byte{
+			"tfstate": compressedStateBytes,
+		},
+	}
+
+	scheme := runtime.NewScheme()
+	_ = corev1.AddToScheme(scheme)
+	k8sClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(tfStateSecret).Build()
+
+	meta := &TFConfigurationMeta{
+		Backend: &backend.K8SBackend{
+			Client:       k8sClient,
+			SecretSuffix: "sensitive-test",
+			SecretNS:     "default",
+		},
+	}
+
+	configuration := v1beta2.Configuration{
+		ObjectMeta: v1.ObjectMeta{
+			Name:      "my-config",
+			Namespace: "default",
+		},
+		Spec: v1beta2.ConfigurationSpec{
+			WriteConnectionSecretToReference: &crossplane.SecretReference{
+				Name:      "my-connection-secret",
+				Namespace: "default",
+			},
+		},
+	}
+
+	t.Run("feature gate ON: sensitive output is redacted in status but real value is in Secret", func(t *testing.T) {
+		featuretest.SetFeatureGateDuringTest(t, feature.DefaultFeatureGate, features.MaskSensitiveOutputs, true)
+
+		statusOutputs, err := meta.getTFOutputs(ctx, k8sClient, configuration)
+		assert.NoError(t, err)
+
+		// Non-sensitive output must be unchanged in status
+		assert.Equal(t, "1.2.3.4", statusOutputs["public_ip"].Value)
+		assert.False(t, statusOutputs["public_ip"].Sensitive)
+
+		// Sensitive output must be redacted in status
+		assert.Equal(t, SensitiveOutputPlaceholder, statusOutputs["db_password"].Value)
+		assert.True(t, statusOutputs["db_password"].Sensitive)
+
+		// The connection Secret must contain the REAL value
+		var connSecret corev1.Secret
+		err = k8sClient.Get(ctx, client.ObjectKey{Name: "my-connection-secret", Namespace: "default"}, &connSecret)
+		assert.NoError(t, err)
+		assert.Equal(t, []byte("s3cr3t"), connSecret.Data["db_password"])
+		assert.Equal(t, []byte("1.2.3.4"), connSecret.Data["public_ip"])
+	})
+
+	t.Run("feature gate OFF: all values pass through to status (legacy behavior)", func(t *testing.T) {
+		featuretest.SetFeatureGateDuringTest(t, feature.DefaultFeatureGate, features.MaskSensitiveOutputs, false)
+
+		statusOutputs, err := meta.getTFOutputs(ctx, k8sClient, configuration)
+		assert.NoError(t, err)
+
+		// Non-sensitive output unchanged
+		assert.Equal(t, "1.2.3.4", statusOutputs["public_ip"].Value)
+
+		// Sensitive output must NOT be redacted when gate is off
+		assert.Equal(t, "s3cr3t", statusOutputs["db_password"].Value)
+		assert.True(t, statusOutputs["db_password"].Sensitive)
+	})
 }
 
 func TestUpdateApplyStatus(t *testing.T) {


### PR DESCRIPTION
## Problem

Fixes #82

Terraform outputs declared with `sensitive = true` were written in
plaintext to `status.apply.outputs` of the `Configuration` CR. Anyone
with `kubectl get configuration` access could read these values.

## Root Cause

`TfStateProperty` in `controllers/process/meta.go` had no `Sensitive`
field, so `json.Unmarshal` silently dropped the `"sensitive": true` flag
from the Terraform state JSON. All outputs were then written verbatim
to the CR status.

## Solution

- **`TfStateProperty`** now captures the `sensitive` flag from the state JSON.
- **`Property` API type** gains a `Sensitive bool` field (additive, non-breaking CRD change).
- **`getTFOutputs()`** now maintains two separate output maps:
  - Real values -> `WriteConnectionSecret` (unchanged)
  - Redacted values -> `status.apply.outputs` (sensitive outputs show `"[sensitive]"`)
- **`MaskSensitiveOutputs` feature gate** (Beta, default: `true`) added to `feature_gate.go` alongside the existing `AllowDeleteProvisioningResource` gate. Operators can opt out via `--feature-gates=MaskSensitiveOutputs=false`.

## Behavior After Fix

```yaml
status:
  apply:
    outputs:
      public_ip:
        value: "1.2.3.4"        # non-sensitive — unchanged
      db_password:
        value: "[sensitive]"    # sensitive — redacted in status
        sensitive: true         # flag tells consumers the value exists
```

The real value of db_password is still available in the WriteConnectionSecret.

## Backward Compatibility
- Non-sensitive outputs: **no change**.
- Sensitive outputs: status shows `[sensitive]` by default. Use `--feature-gates=MaskSensitiveOutputs=false` to restore old behavior.
- The `WriteConnectionSecret` always contains real values regardless of the gate.

## Tests
- TestTfStatePropertyToPropertySensitive` - Sensitive flag propagates through ToProperty()
- `TestGetTFOutputsSensitiveMasking` - gate ON redacts status; gate OFF passes values through.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Redacts Terraform outputs marked `sensitive = true` in `Configuration` status to prevent plaintext exposure. Real values are still written to the connection Secret. Fixes #82.

- **Bug Fixes**
  - Capture the `sensitive` flag from TF state and add `Property.Sensitive` to the API and CRD (additive).
  - Redact status values to "[sensitive]" when the `MaskSensitiveOutputs` gate is on (default: true); always write real values to `WriteConnectionSecret`.
  - Allow opt-out with `--feature-gates=MaskSensitiveOutputs=false` for legacy status behavior.

<sup>Written for commit 2ea7056b15ca03ced2628d12cf40dcd53fa5e318. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kubevela/terraform-controller/pull/400?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

