### PR TITLE
fix: pin ssh-agent socket path and resolve stale Configuration status on apply

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -38,7 +38,7 @@ jobs:
 
     steps:
       - name: Set up Go
-        uses: actions/setup-go@v1
+        uses: actions/setup-go@v5
         with:
           go-version: ${{ env.GO_VERSION }}
         id: go

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Set up Go
-        uses: actions/setup-go@v1
+        uses: actions/setup-go@v5
         with:
           go-version: ${{ env.GO_VERSION }}
       - uses: actions/checkout@v2
@@ -35,7 +35,7 @@ jobs:
 
     steps:
       - name: Set up Go
-        uses: actions/setup-go@v1
+        uses: actions/setup-go@v5
         with:
           go-version: ${{ env.GO_VERSION }}
         id: go

--- a/controllers/configuration/backend/s3_test.go
+++ b/controllers/configuration/backend/s3_test.go
@@ -19,7 +19,7 @@ package backend
 import (
 	"bytes"
 	"context"
-	"io/ioutil"
+	"io"
 	"reflect"
 	"testing"
 
@@ -127,7 +127,7 @@ func (s *mockS3Client) GetObject(input *s3.GetObjectInput) (*s3.GetObjectOutput,
 	}
 
 	if resp != "" {
-		body := ioutil.NopCloser(bytes.NewBuffer([]byte(resp)))
+		body := io.NopCloser(bytes.NewBuffer([]byte(resp)))
 		return &s3.GetObjectOutput{Body: body}, nil
 	}
 	return nil, nil

--- a/controllers/configuration_controller.go
+++ b/controllers/configuration_controller.go
@@ -161,7 +161,10 @@ func (r *ConfigurationReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 		return ctrl.Result{RequeueAfter: 5 * time.Second}, nil
 	}
 
-	return ctrl.Result{}, nil
+	// Terraform apply is still running (no error yet, but the job hasn't reported Succeeded either).
+	// Requeue so we keep checking until the job's Succeeded count is observed on a later reconcile,
+	// since this controller does not watch the apply Job/Pod directly.
+	return ctrl.Result{RequeueAfter: 5 * time.Second}, nil
 }
 
 func (r *ConfigurationReconciler) terraformApply(ctx context.Context, configuration v1beta2.Configuration, meta *process.TFConfigurationMeta) error {

--- a/controllers/configuration_controller_test.go
+++ b/controllers/configuration_controller_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/oam-dev/terraform-controller/controllers/configuration/backend"
 	"github.com/oam-dev/terraform-controller/controllers/process"
 	providerpkg "github.com/oam-dev/terraform-controller/controllers/provider"
+	"github.com/oam-dev/terraform-controller/controllers/terraform"
 	"github.com/stretchr/testify/assert"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -465,6 +466,104 @@ terraform {
 			}
 		})
 	}
+}
+
+func TestConfigurationReconcileApplyStillRunning(t *testing.T) {
+	req := ctrl.Request{}
+	req.NamespacedName = k8stypes.NamespacedName{
+		Name:      "a",
+		Namespace: "b",
+	}
+
+	ctx := context.Background()
+	s := runtime.NewScheme()
+	v1beta1.AddToScheme(s)
+	v1beta2.AddToScheme(s)
+	corev1.AddToScheme(s)
+	batchv1.AddToScheme(s)
+
+	ak := providerpkg.AlibabaCloudCredentials{
+		AccessKeyID:     "aaaa",
+		AccessKeySecret: "bbbbb",
+	}
+	credentials, err := json.Marshal(&ak)
+	assert.Nil(t, err)
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "default",
+			Namespace: "default",
+		},
+		Data: map[string][]byte{
+			"credentials": credentials,
+		},
+		Type: corev1.SecretTypeOpaque,
+	}
+
+	provider := &v1beta1.Provider{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "terraform.core.oam.dev/v1beta2",
+			Kind:       "Provider",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "default",
+			Namespace: "default",
+		},
+		Spec: v1beta1.ProviderSpec{
+			Provider: "alibaba",
+			Credentials: v1beta1.ProviderCredentials{
+				Source: "Secret",
+				SecretRef: &crossplane.SecretKeySelector{
+					SecretReference: crossplane.SecretReference{
+						Name:      "default",
+						Namespace: "default",
+					},
+					Key: "credentials",
+				},
+			},
+			Region: "xxx",
+		},
+	}
+
+	configuration := &v1beta2.Configuration{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       "a",
+			Namespace:  "b",
+			Finalizers: []string{configurationFinalizer},
+			UID:        "67890",
+		},
+		Spec: v1beta2.ConfigurationSpec{
+			HCL: "c",
+		},
+	}
+
+	namespace := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "builds"}}
+	r := &ConfigurationReconciler{ControllerNamespace: "builds"}
+	r.Client = fake.NewClientBuilder().
+		WithScheme(s).
+		WithObjects(namespace, secret, provider, configuration).
+		Build()
+
+	patches := gomonkey.NewPatches()
+	patches.ApplyMethod(reflect.TypeOf(&sts.Client{}), "GetCallerIdentity", func(_ *sts.Client, request *sts.GetCallerIdentityRequest) (*sts.GetCallerIdentityResponse, error) {
+		return nil, nil
+	})
+	patches.ApplyFunc(sts.NewClientWithAccessKey, func(regionId, accessKeyId, accessKeySecret string) (*sts.Client, error) {
+		return &sts.Client{}, nil
+	})
+	patches.ApplyFunc(sts.NewClientWithStsToken, func(regionId, accessKeyId, accessKeySecret, stsToken string) (*sts.Client, error) {
+		return &sts.Client{}, nil
+	})
+	patches.ApplyFunc(providerpkg.GetProviderCredentials, func(ctx context.Context, k8sClient client.Client, providerObj *v1beta1.Provider, region string) (map[string]string, error) {
+		return map[string]string{}, nil
+	})
+	patches.ApplyFunc(terraform.GetTerraformStatus, func(ctx context.Context, jobNamespace, jobName, containerName, initContainerName string) (types.ConfigurationState, error) {
+		return types.ConfigurationProvisioningAndChecking, nil
+	})
+	defer patches.Reset()
+
+	result, err := r.Reconcile(ctx, req)
+	assert.Nil(t, err)
+	assert.Equal(t, ctrl.Result{RequeueAfter: 5 * time.Second}, result)
 }
 
 func TestInitTFConfigurationMetaWithJobEnv(t *testing.T) {

--- a/controllers/process/container/git.go
+++ b/controllers/process/container/git.go
@@ -56,7 +56,7 @@ func (a *Assembler) getCloneCommand() []string {
 
 	// Check for git credentials, mount the SSH known hosts and private key, add private key into the SSH authentication agent
 	if a.GitCredential {
-		sshCommand := fmt.Sprintf("eval `ssh-agent` && ssh-add %s/%s", types.GitAuthConfigVolumeMountPath, v1.SSHAuthPrivateKey)
+		sshCommand := fmt.Sprintf("eval `ssh-agent -a /tmp/ssh-agent.sock` && ssh-add %s/%s", types.GitAuthConfigVolumeMountPath, v1.SSHAuthPrivateKey)
 		cloneCommand = fmt.Sprintf("%s && %s", sshCommand, cloneCommand)
 	}
 

--- a/controllers/process/container/git_test.go
+++ b/controllers/process/container/git_test.go
@@ -1,10 +1,35 @@
 package container
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/oam-dev/terraform-controller/api/types"
 )
+
+// Test_getCloneCommand_GitCredential guards against regressing to the bare
+// `eval `ssh-agent`` form: on OpenSSH 9.x+ (e.g. alpine/git:latest) ssh-agent
+// defaults its socket to $HOME/.ssh/agent, but that path is a Secret volume
+// mount and always read-only, so ssh-agent fails to start. Binding to an
+// explicit socket path under /tmp avoids that.
+func Test_getCloneCommand_GitCredential(t *testing.T) {
+	a := &Assembler{
+		GitCredential: true,
+		Git: types.Git{
+			URL: "git@git-server:simple-terraform-module.git",
+		},
+	}
+
+	got := a.getCloneCommand()
+	command := strings.Join(got, " ")
+
+	if !strings.Contains(command, "ssh-agent -a /tmp/ssh-agent.sock") {
+		t.Errorf("expected clone command to bind ssh-agent to an explicit writable socket path, got: %s", command)
+	}
+	if strings.Contains(command, "eval `ssh-agent`") {
+		t.Errorf("clone command must not use bare `ssh-agent` (breaks under read-only /root/.ssh Secret mount with OpenSSH 9.x+), got: %s", command)
+	}
+}
 
 func Test_getCheckoutObj(t *testing.T) {
 	tests := []struct {

--- a/controllers/process/container/git_test.go
+++ b/controllers/process/container/git_test.go
@@ -7,11 +7,9 @@ import (
 	"github.com/oam-dev/terraform-controller/api/types"
 )
 
-// Test_getCloneCommand_GitCredential guards against regressing to the bare
-// `eval `ssh-agent`` form: on OpenSSH 9.x+ (e.g. alpine/git:latest) ssh-agent
-// defaults its socket to $HOME/.ssh/agent, but that path is a Secret volume
-// mount and always read-only, so ssh-agent fails to start. Binding to an
-// explicit socket path under /tmp avoids that.
+// Test_getCloneCommand_GitCredential guards against regressing to bare
+// ssh-agent, whose default socket path ($HOME/.ssh/agent) is a read-only
+// Secret mount.
 func Test_getCloneCommand_GitCredential(t *testing.T) {
 	a := &Assembler{
 		GitCredential: true,

--- a/controllers/terraform/logging_test.go
+++ b/controllers/terraform/logging_test.go
@@ -3,7 +3,6 @@ package terraform
 import (
 	"context"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"reflect"
@@ -123,7 +122,7 @@ func TestFlushStream(t *testing.T) {
 		{
 			name: "Flush stream",
 			args: args{
-				rc:   ioutil.NopCloser(strings.NewReader("xxx")),
+				rc:   io.NopCloser(strings.NewReader("xxx")),
 				name: "p1",
 			},
 			want: want{},

--- a/examples/git-credentials/git-push-job.yaml
+++ b/examples/git-credentials/git-push-job.yaml
@@ -51,7 +51,7 @@ spec:
               set -x &&
               eval $(ssh-agent) &&
               ssh-add /usr/.ssh/id_rsa &&
-              mkdir /root/.ssh &&
+              mkdir -p /root/.ssh &&
               ssh-keyscan git-server >> /root/.ssh/known_hosts &&
               mkdir /usr/simple-terraform-module &&
               cd /usr/simple-terraform-module &&


### PR DESCRIPTION
Tracking issue: #402, https://github.com/kubevela/terraform-controller/issues/398 and  I have n't created the issue for other fix cause I encounter all others issue during testing. 


 - ssh-agent defaulted its socket to $HOME/.ssh/agent, which is a read-only Secret mount, pinned it to an explicit /tmp path so git-over-SSH clones don't hang, plus a regression test. (Issue at E2E test)
  - Reconcile returned an empty result (no requeue) whenever terraform apply was still running without errors, and   since the controller doesn't watch the apply Job/Pod, the Configuration could get stuck reporting a stale ProvisioningAndChecking status forever even after apply succeeded. Now requeues after 5s until Job.Status.Succeeded is observed.(Issue was at E2E test)
  - Bumped actions/setup-go from v1 to v5 in unit-test/format workflows, v1 doesn't know about Go 1.23.8 and runs on a deprecated Node runtime.
  - Minor cleanup: ioutil.NopCloser to io.NopCloser.




<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes git-over-SSH cloning by pinning `ssh-agent` to `/tmp/ssh-agent.sock`. Also requeues Configuration every 5s while apply runs so status updates when it finishes.

- **Bug Fixes**
  - Bind `ssh-agent` to `/tmp/ssh-agent.sock`; add a unit test; update example to use `mkdir -p`.
  - Requeue Configuration after 5s when apply is still running; add coverage for this path.
  - Replace `ioutil.NopCloser` with `io.NopCloser` and drop `io/ioutil` in tests.

- **Dependencies**
  - Bump CI to `actions/setup-go@v5`.

<sup>Written for commit 4a76ff12a75d0e05556ad74a6d779afd0ba8ff0d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kubevela/terraform-controller/pull/403?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->









