### PR TITLE
fix: bind ssh-agent to explicit socket path to avoid read-only /root/.ssh/mount

### DIFF
--- a/controllers/process/container/git.go
+++ b/controllers/process/container/git.go
@@ -56,7 +56,7 @@ func (a *Assembler) getCloneCommand() []string {
 
 	// Check for git credentials, mount the SSH known hosts and private key, add private key into the SSH authentication agent
 	if a.GitCredential {
-		sshCommand := fmt.Sprintf("eval `ssh-agent` && ssh-add %s/%s", types.GitAuthConfigVolumeMountPath, v1.SSHAuthPrivateKey)
+		sshCommand := fmt.Sprintf("eval `ssh-agent -a /tmp/ssh-agent.sock` && ssh-add %s/%s", types.GitAuthConfigVolumeMountPath, v1.SSHAuthPrivateKey)
 		cloneCommand = fmt.Sprintf("%s && %s", sshCommand, cloneCommand)
 	}
 

--- a/examples/git-credentials/git-push-job.yaml
+++ b/examples/git-credentials/git-push-job.yaml
@@ -51,7 +51,7 @@ spec:
               set -x &&
               eval $(ssh-agent) &&
               ssh-add /usr/.ssh/id_rsa &&
-              mkdir /root/.ssh &&
+              mkdir -p /root/.ssh &&
               ssh-keyscan git-server >> /root/.ssh/known_hosts &&
               mkdir /usr/simple-terraform-module &&
               cd /usr/simple-terraform-module &&


### PR DESCRIPTION

Modern OpenSSH ssh-agent defaults its control socket to $HOME/.ssh/agent/, but the git-configuration init container mounts the git SSH credentials Secret directly at /root/.ssh, which Kubernetes always mounts read-only. This made ssh-agent fail to create its socket directory, breaking git-over-ssh cloning. Also fixes the equivalent issue in the git-credentials e2e example job.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bind `ssh-agent` to `/tmp/ssh-agent.sock` to bypass the read-only `/root/.ssh` Secret mount, restoring git-over-ssh cloning. Also make the example job create `/root/.ssh` idempotently.

- **Bug Fixes**
  - Controller: run `ssh-agent -a /tmp/ssh-agent.sock` before `ssh-add` to avoid the default `$HOME/.ssh/agent` path.
  - Example job: use `mkdir -p /root/.ssh` before writing `known_hosts`.

<sup>Written for commit 5ab0f4da8b7dc53bd4a008912ff9ca742349da10. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kubevela/terraform-controller/pull/405?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

